### PR TITLE
:ghost: Erroring full analysis mode is not supported

### DIFF
--- a/src/provider/csharp.rs
+++ b/src/provider/csharp.rs
@@ -101,9 +101,12 @@ impl ProviderService for CSharpProvider {
         let mut config_guard = self.config.lock().await;
         let saved_config = config_guard.insert(r.get_ref().clone());
 
-        // Hard-code analysis_mode to SourceOnly to always run source-analysis
-        // TODO: fetch analysis_mode from config when we get a real use case for full analysis
-        let analysis_mode = AnalysisMode::SourceOnly;
+        let analysis_mode = AnalysisMode::from(&saved_config.analysis_mode);
+        if analysis_mode == AnalysisMode::Full {
+            return Err(Status::unimplemented(
+                "Full analysis mode is not currently supported. Use source-only mode.",
+            ));
+        }
         let location = PathBuf::from(saved_config.location.clone());
         let tools = Project::get_tools(&saved_config.provider_specific_config)
             .map_err(|e| Status::invalid_argument(format!("unalble to find tools: {}", e)))?;


### PR DESCRIPTION
```
$ grpcurl -max-time 1000 -plaintext -d '{
    "analysisMode": "full",
    "location": "'$(pwd)'/testdata/nerd-dinner",
    "providerSpecificConfig": {
      "ilspy_cmd": "'${HOME}'/.dotnet/tools/ilspycmd",
      "paket_cmd": "'${HOME}'/.dotnet/tools/paket",
      "dotnet_install_cmd": "'$(pwd)'/scripts/dotnet-install.sh"
    }
  }' localhost:9000 provider.ProviderService.Init
ERROR:
  Code: Unimplemented
  Message: Full analysis mode is not currently supported. Use source-only mode.
```