### PR TITLE
:bug: Update e2e demo-output baseline from CI

### DIFF
--- a/e2e-tests/demo-output.yaml
+++ b/e2e-tests/demo-output.yaml
@@ -12,6 +12,197 @@
     - Configuration and State Management Migration
     - Runtime and Utility Class Migration
   violations:
+    dotnet-core-antiforgery-01:
+      description: ValidateAntiForgeryToken works similarly but review implementation
+      category: optional
+      labels:
+      - konveyor.io/source=dotnet
+      - konveyor.io/target=dotnet-core
+      incidents:
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          ValidateAntiForgeryToken attribute exists in ASP.NET Core but works slightly differently.
+
+          Review actions:
+          - Ensure anti-forgery tokens are properly configured in Startup
+          - The attribute should work without changes in most cases
+          - Consider using [AutoValidateAntiforgeryToken] globally in filters
+          - Review any custom anti-forgery validation logic
+        codeSnip: " 25          {\n 26              ViewBag.ReturnUrl = returnUrl;\n 27              return View();\n 28          }\n 29  \n 30          //\n 31          // POST: /Account/Login\n 32  \n 33          [HttpPost]\n 34          [AllowAnonymous]\n 35          [ValidateAntiForgeryToken]\n 36          public ActionResult Login(LoginModel model, string returnUrl)\n 37          {\n 38              if (ModelState.IsValid && WebSecurity.Login(model.UserName, model.Password, persistCookie: model.RememberMe))\n 39              {\n 40                  return RedirectToLocal(returnUrl);\n 41              }\n 42  \n 43              // If we got this far, something failed, redisplay form\n 44              ModelState.AddModelError(\"\", \"The user name or password provided is incorrect.\");\n 45              return View(model);"
+        lineNumber: 34
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ValidateAntiForgeryTokenAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ValidateAntiForgeryTokenAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          ValidateAntiForgeryToken attribute exists in ASP.NET Core but works slightly differently.
+
+          Review actions:
+          - Ensure anti-forgery tokens are properly configured in Startup
+          - The attribute should work without changes in most cases
+          - Consider using [AutoValidateAntiforgeryToken] globally in filters
+          - Review any custom anti-forgery validation logic
+        codeSnip: " 42  \n 43              // If we got this far, something failed, redisplay form\n 44              ModelState.AddModelError(\"\", \"The user name or password provided is incorrect.\");\n 45              return View(model);\n 46          }\n 47  \n 48          //\n 49          // POST: /Account/LogOff\n 50  \n 51          [HttpPost]\n 52          [ValidateAntiForgeryToken]\n 53          public ActionResult LogOff()\n 54          {\n 55              WebSecurity.Logout();\n 56  \n 57              return RedirectToAction(\"Index\", \"Home\");\n 58          }\n 59  \n 60          //\n 61          // GET: /Account/Register\n 62  "
+        lineNumber: 51
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ValidateAntiForgeryTokenAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ValidateAntiForgeryTokenAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          ValidateAntiForgeryToken attribute exists in ASP.NET Core but works slightly differently.
+
+          Review actions:
+          - Ensure anti-forgery tokens are properly configured in Startup
+          - The attribute should work without changes in most cases
+          - Consider using [AutoValidateAntiforgeryToken] globally in filters
+          - Review any custom anti-forgery validation logic
+        codeSnip: " 64          public ActionResult Register()\n 65          {\n 66              return View();\n 67          }\n 68  \n 69          //\n 70          // POST: /Account/Register\n 71  \n 72          [HttpPost]\n 73          [AllowAnonymous]\n 74          [ValidateAntiForgeryToken]\n 75          public ActionResult Register(RegisterModel model)\n 76          {\n 77              if (ModelState.IsValid)\n 78              {\n 79                  // Attempt to register the user\n 80                  try\n 81                  {\n 82                      WebSecurity.CreateUserAndAccount(model.UserName, model.Password);\n 83                      WebSecurity.Login(model.UserName, model.Password);\n 84                      return RedirectToAction(\"Index\", \"Home\");"
+        lineNumber: 73
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ValidateAntiForgeryTokenAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ValidateAntiForgeryTokenAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          ValidateAntiForgeryToken attribute exists in ASP.NET Core but works slightly differently.
+
+          Review actions:
+          - Ensure anti-forgery tokens are properly configured in Startup
+          - The attribute should work without changes in most cases
+          - Consider using [AutoValidateAntiforgeryToken] globally in filters
+          - Review any custom anti-forgery validation logic
+        codeSnip: " 90              }\n 91  \n 92              // If we got this far, something failed, redisplay form\n 93              return View(model);\n 94          }\n 95  \n 96          //\n 97          // POST: /Account/Disassociate\n 98  \n 99          [HttpPost]\n100          [ValidateAntiForgeryToken]\n101          public ActionResult Disassociate(string provider, string providerUserId)\n102          {\n103              string ownerAccount = OAuthWebSecurity.GetUserName(provider, providerUserId);\n104              ManageMessageId? message = null;\n105  \n106              // Only disassociate the account if the currently logged in user is the owner\n107              if (ownerAccount == User.Identity.Name)\n108              {\n109                  // Use a transaction to prevent the user from deleting their last login credential\n110                  using (var scope = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions { IsolationLevel = IsolationLevel.Serializable }))"
+        lineNumber: 99
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ValidateAntiForgeryTokenAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ValidateAntiForgeryTokenAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          ValidateAntiForgeryToken attribute exists in ASP.NET Core but works slightly differently.
+
+          Review actions:
+          - Ensure anti-forgery tokens are properly configured in Startup
+          - The attribute should work without changes in most cases
+          - Consider using [AutoValidateAntiforgeryToken] globally in filters
+          - Review any custom anti-forgery validation logic
+        codeSnip: "134                  : \"\";\n135              ViewBag.HasLocalPassword = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n136              ViewBag.ReturnUrl = Url.Action(\"Manage\");\n137              return View();\n138          }\n139  \n140          //\n141          // POST: /Account/Manage\n142  \n143          [HttpPost]\n144          [ValidateAntiForgeryToken]\n145          public ActionResult Manage(LocalPasswordModel model)\n146          {\n147              bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n148              ViewBag.HasLocalPassword = hasLocalAccount;\n149              ViewBag.ReturnUrl = Url.Action(\"Manage\");\n150              if (hasLocalAccount)\n151              {\n152                  if (ModelState.IsValid)\n153                  {\n154                      // ChangePassword will throw an exception rather than return false in certain failure scenarios."
+        lineNumber: 143
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ValidateAntiForgeryTokenAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ValidateAntiForgeryTokenAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          ValidateAntiForgeryToken attribute exists in ASP.NET Core but works slightly differently.
+
+          Review actions:
+          - Ensure anti-forgery tokens are properly configured in Startup
+          - The attribute should work without changes in most cases
+          - Consider using [AutoValidateAntiforgeryToken] globally in filters
+          - Review any custom anti-forgery validation logic
+        codeSnip: "198  \n199              // If we got this far, something failed, redisplay form\n200              return View(model);\n201          }\n202  \n203          //\n204          // POST: /Account/ExternalLogin\n205  \n206          [HttpPost]\n207          [AllowAnonymous]\n208          [ValidateAntiForgeryToken]\n209          public ActionResult ExternalLogin(string provider, string returnUrl)\n210          {\n211              return new ExternalLoginResult(provider, Url.Action(\"ExternalLoginCallback\", new { ReturnUrl = returnUrl }));\n212          }\n213  \n214          //\n215          // GET: /Account/ExternalLoginCallback\n216  \n217          [AllowAnonymous]\n218          public ActionResult ExternalLoginCallback(string returnUrl)"
+        lineNumber: 207
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ValidateAntiForgeryTokenAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ValidateAntiForgeryTokenAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          ValidateAntiForgeryToken attribute exists in ASP.NET Core but works slightly differently.
+
+          Review actions:
+          - Ensure anti-forgery tokens are properly configured in Startup
+          - The attribute should work without changes in most cases
+          - Consider using [AutoValidateAntiforgeryToken] globally in filters
+          - Review any custom anti-forgery validation logic
+        codeSnip: "242                  ViewBag.ReturnUrl = returnUrl;\n243                  return View(\"ExternalLoginConfirmation\", new RegisterExternalLoginModel { UserName = result.UserName, ExternalLoginData = loginData });\n244              }\n245          }\n246  \n247          //\n248          // POST: /Account/ExternalLoginConfirmation\n249  \n250          [HttpPost]\n251          [AllowAnonymous]\n252          [ValidateAntiForgeryToken]\n253          public ActionResult ExternalLoginConfirmation(RegisterExternalLoginModel model, string returnUrl)\n254          {\n255              string provider = null;\n256              string providerUserId = null;\n257  \n258              if (User.Identity.IsAuthenticated || !OAuthWebSecurity.TryDeserializeProviderUserId(model.ExternalLoginData, out provider, out providerUserId))\n259              {\n260                  return RedirectToAction(\"Manage\");\n261              }\n262  "
+        lineNumber: 251
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ValidateAntiForgeryTokenAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ValidateAntiForgeryTokenAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          ValidateAntiForgeryToken attribute exists in ASP.NET Core but works slightly differently.
+
+          Review actions:
+          - Ensure anti-forgery tokens are properly configured in Startup
+          - The attribute should work without changes in most cases
+          - Consider using [AutoValidateAntiforgeryToken] globally in filters
+          - Review any custom anti-forgery validation logic
+        codeSnip: " 49                  EventDate = DateTime.Now.AddDays(7),\n 50                  HostedBy = User.Identity.Name\n 51              };\n 52  \n 53              return View(dinner);\n 54          }\n 55  \n 56          //\n 57          // POST: /Dinners/Create\n 58  \n 59          [HttpPost, Authorize, ValidateAntiForgeryToken]\n 60          public ActionResult Create(Dinner dinner)\n 61          {\n 62              if (ModelState.IsValid)\n 63              {\n 64                  dinner.HostedBy = User.Identity.Name;\n 65  \n 66                  RSVP rsvp = new RSVP();\n 67                  rsvp.AttendeeName = User.Identity.Name;\n 68  \n 69                  dinner.RSVPs = new List<RSVP>();"
+        lineNumber: 58
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ValidateAntiForgeryTokenAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ValidateAntiForgeryTokenAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          ValidateAntiForgeryToken attribute exists in ASP.NET Core but works slightly differently.
+
+          Review actions:
+          - Ensure anti-forgery tokens are properly configured in Startup
+          - The attribute should work without changes in most cases
+          - Consider using [AutoValidateAntiforgeryToken] globally in filters
+          - Review any custom anti-forgery validation logic
+        codeSnip: " 91              if (!dinner.IsHostedBy(User.Identity.Name))\n 92              {\n 93                  return View(\"InvalidOwner\");\n 94              }\n 95              return View(dinner);\n 96          }\n 97  \n 98          //\n 99          // POST: /Dinners/Edit/5\n100  \n101          [HttpPost, Authorize, ValidateAntiForgeryToken]\n102          public ActionResult Edit(Dinner dinner)\n103          {\n104              if (!dinner.IsHostedBy(User.Identity.Name))\n105              {\n106                  return View(\"InvalidOwner\");\n107              }\n108  \n109              if (ModelState.IsValid)\n110              {\n111                  db.Entry(dinner).State = EntityState.Modified;"
+        lineNumber: 100
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ValidateAntiForgeryTokenAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ValidateAntiForgeryTokenAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          ValidateAntiForgeryToken attribute exists in ASP.NET Core but works slightly differently.
+
+          Review actions:
+          - Ensure anti-forgery tokens are properly configured in Startup
+          - The attribute should work without changes in most cases
+          - Consider using [AutoValidateAntiforgeryToken] globally in filters
+          - Review any custom anti-forgery validation logic
+        codeSnip: "129              if (!dinner.IsHostedBy(User.Identity.Name))\n130              {\n131                  return View(\"InvalidOwner\");\n132              }\n133              return View(dinner);\n134          }\n135  \n136          //\n137          // POST: /Dinners/Delete/5\n138  \n139          [HttpPost, ActionName(\"Delete\"), Authorize, ValidateAntiForgeryToken]\n140          public ActionResult DeleteConfirmed(int id)\n141          {\n142              Dinner dinner = db.Dinners.Find(id);\n143  \n144              if (!dinner.IsHostedBy(User.Identity.Name))\n145              {\n146                  return View(\"InvalidOwner\");\n147              }\n148  \n149              db.Dinners.Remove(dinner);"
+        lineNumber: 138
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ValidateAntiForgeryTokenAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ValidateAntiForgeryTokenAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      links:
+      - url: https://learn.microsoft.com/en-us/aspnet/core/security/anti-request-forgery
+        title: Prevent Cross-Site Request Forgery (XSRF/CSRF) attacks
+      effort: 1
     dotnet-core-ef-dbcontext-01:
       description: System.Data.Entity.DbContext must be replaced with Entity Framework Core
       category: mandatory
@@ -19,6 +210,204 @@
       - konveyor.io/source=dotnet
       - konveyor.io/target=dotnet-core
       incidents:
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          System.Data.Entity is not available in .NET Core. Entity Framework 6 must be migrated to Entity Framework Core.
+
+          Migration actions:
+          - Install Microsoft.EntityFrameworkCore NuGet package
+          - Install database provider package (e.g., Microsoft.EntityFrameworkCore.SqlServer)
+          - Change using from System.Data.Entity to Microsoft.EntityFrameworkCore
+          - Review DbContext configuration - some APIs have changed
+          - Update connection string configuration (moved from Web.config to appsettings.json)
+          - Review LINQ queries - some EF6 features are not supported in EF Core
+          - Test thoroughly as EF Core has different behavior in some scenarios
+        codeSnip: "264              {\n265                  // Insert a new user into the database\n266                  using (UsersContext db = new UsersContext())\n267                  {\n268                      UserProfile user = db.UserProfiles.FirstOrDefault(u => u.UserName.ToLower() == model.UserName.ToLower());\n269                      // Check if user already exists\n270                      if (user == null)\n271                      {\n272                          // Insert name into the profile table\n273                          db.UserProfiles.Add(new UserProfile { UserName = model.UserName });\n274                          db.SaveChanges();\n275  \n276                          OAuthWebSecurity.CreateOrUpdateAccount(provider, providerUserId, model.UserName);\n277                          OAuthWebSecurity.Login(provider, providerUserId, createPersistentCookie: false);\n278  \n279                          return RedirectToLocal(returnUrl);\n280                      }\n281                      else\n282                      {\n283                          ModelState.AddModelError(\"UserName\", \"User name already exists. Please enter a different user name.\");\n284                      }"
+        lineNumber: 273
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: DbContext
+          fqdn_method: SaveChanges
+          fqdn_namespace: System.Data.Entity
+          symbol: db.SaveChanges
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          System.Data.Entity is not available in .NET Core. Entity Framework 6 must be migrated to Entity Framework Core.
+
+          Migration actions:
+          - Install Microsoft.EntityFrameworkCore NuGet package
+          - Install database provider package (e.g., Microsoft.EntityFrameworkCore.SqlServer)
+          - Change using from System.Data.Entity to Microsoft.EntityFrameworkCore
+          - Review DbContext configuration - some APIs have changed
+          - Update connection string configuration (moved from Web.config to appsettings.json)
+          - Review LINQ queries - some EF6 features are not supported in EF Core
+          - Test thoroughly as EF Core has different behavior in some scenarios
+        codeSnip: " 63              {\n 64                  dinner.HostedBy = User.Identity.Name;\n 65  \n 66                  RSVP rsvp = new RSVP();\n 67                  rsvp.AttendeeName = User.Identity.Name;\n 68  \n 69                  dinner.RSVPs = new List<RSVP>();\n 70                  dinner.RSVPs.Add(rsvp);\n 71  \n 72                  db.Dinners.Add(dinner);\n 73                  db.SaveChanges();\n 74                  return RedirectToAction(\"Index\");\n 75              }\n 76  \n 77              return View(dinner);\n 78          }\n 79  \n 80          //\n 81          // GET: /Dinners/Edit/5\n 82  \n 83          [Authorize]"
+        lineNumber: 72
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: DbContext
+          fqdn_method: SaveChanges
+          fqdn_namespace: System.Data.Entity
+          symbol: db.SaveChanges
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          System.Data.Entity is not available in .NET Core. Entity Framework 6 must be migrated to Entity Framework Core.
+
+          Migration actions:
+          - Install Microsoft.EntityFrameworkCore NuGet package
+          - Install database provider package (e.g., Microsoft.EntityFrameworkCore.SqlServer)
+          - Change using from System.Data.Entity to Microsoft.EntityFrameworkCore
+          - Review DbContext configuration - some APIs have changed
+          - Update connection string configuration (moved from Web.config to appsettings.json)
+          - Review LINQ queries - some EF6 features are not supported in EF Core
+          - Test thoroughly as EF Core has different behavior in some scenarios
+        codeSnip: "101          [HttpPost, Authorize, ValidateAntiForgeryToken]\n102          public ActionResult Edit(Dinner dinner)\n103          {\n104              if (!dinner.IsHostedBy(User.Identity.Name))\n105              {\n106                  return View(\"InvalidOwner\");\n107              }\n108  \n109              if (ModelState.IsValid)\n110              {\n111                  db.Entry(dinner).State = EntityState.Modified;\n112                  db.SaveChanges();\n113                  return RedirectToAction(\"Index\");\n114              }\n115              return View(dinner);\n116          }\n117  \n118          //\n119          // GET: /Dinners/Delete/5\n120  \n121          [Authorize]"
+        lineNumber: 110
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: DbContext
+          fqdn_method: Entry
+          fqdn_namespace: System.Data.Entity
+          symbol: db.Entry
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          System.Data.Entity is not available in .NET Core. Entity Framework 6 must be migrated to Entity Framework Core.
+
+          Migration actions:
+          - Install Microsoft.EntityFrameworkCore NuGet package
+          - Install database provider package (e.g., Microsoft.EntityFrameworkCore.SqlServer)
+          - Change using from System.Data.Entity to Microsoft.EntityFrameworkCore
+          - Review DbContext configuration - some APIs have changed
+          - Update connection string configuration (moved from Web.config to appsettings.json)
+          - Review LINQ queries - some EF6 features are not supported in EF Core
+          - Test thoroughly as EF Core has different behavior in some scenarios
+        codeSnip: "102          public ActionResult Edit(Dinner dinner)\n103          {\n104              if (!dinner.IsHostedBy(User.Identity.Name))\n105              {\n106                  return View(\"InvalidOwner\");\n107              }\n108  \n109              if (ModelState.IsValid)\n110              {\n111                  db.Entry(dinner).State = EntityState.Modified;\n112                  db.SaveChanges();\n113                  return RedirectToAction(\"Index\");\n114              }\n115              return View(dinner);\n116          }\n117  \n118          //\n119          // GET: /Dinners/Delete/5\n120  \n121          [Authorize]\n122          public ActionResult Delete(int id = 0)"
+        lineNumber: 111
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: DbContext
+          fqdn_method: SaveChanges
+          fqdn_namespace: System.Data.Entity
+          symbol: db.SaveChanges
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          System.Data.Entity is not available in .NET Core. Entity Framework 6 must be migrated to Entity Framework Core.
+
+          Migration actions:
+          - Install Microsoft.EntityFrameworkCore NuGet package
+          - Install database provider package (e.g., Microsoft.EntityFrameworkCore.SqlServer)
+          - Change using from System.Data.Entity to Microsoft.EntityFrameworkCore
+          - Review DbContext configuration - some APIs have changed
+          - Update connection string configuration (moved from Web.config to appsettings.json)
+          - Review LINQ queries - some EF6 features are not supported in EF Core
+          - Test thoroughly as EF Core has different behavior in some scenarios
+        codeSnip: "140          public ActionResult DeleteConfirmed(int id)\n141          {\n142              Dinner dinner = db.Dinners.Find(id);\n143  \n144              if (!dinner.IsHostedBy(User.Identity.Name))\n145              {\n146                  return View(\"InvalidOwner\");\n147              }\n148  \n149              db.Dinners.Remove(dinner);\n150              db.SaveChanges();\n151              return RedirectToAction(\"Index\");\n152          }\n153  \n154          protected override void Dispose(bool disposing)\n155          {\n156              db.Dispose();\n157              base.Dispose(disposing);\n158          }\n159  \n160          public ActionResult WebSlicePopular()"
+        lineNumber: 149
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: DbContext
+          fqdn_method: SaveChanges
+          fqdn_namespace: System.Data.Entity
+          symbol: db.SaveChanges
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          System.Data.Entity is not available in .NET Core. Entity Framework 6 must be migrated to Entity Framework Core.
+
+          Migration actions:
+          - Install Microsoft.EntityFrameworkCore NuGet package
+          - Install database provider package (e.g., Microsoft.EntityFrameworkCore.SqlServer)
+          - Change using from System.Data.Entity to Microsoft.EntityFrameworkCore
+          - Review DbContext configuration - some APIs have changed
+          - Update connection string configuration (moved from Web.config to appsettings.json)
+          - Review LINQ queries - some EF6 features are not supported in EF Core
+          - Test thoroughly as EF Core has different behavior in some scenarios
+        codeSnip: "146                  return View(\"InvalidOwner\");\n147              }\n148  \n149              db.Dinners.Remove(dinner);\n150              db.SaveChanges();\n151              return RedirectToAction(\"Index\");\n152          }\n153  \n154          protected override void Dispose(bool disposing)\n155          {\n156              db.Dispose();\n157              base.Dispose(disposing);\n158          }\n159  \n160          public ActionResult WebSlicePopular()\n161          {\n162              ViewData[\"Title\"] = \"Popular Nerd Dinners\";\n163              var model = from dinner in db.Dinners\n164                          where dinner.EventDate >= DateTime.Now\n165                          orderby dinner.RSVPs.Count descending\n166                          select dinner;"
+        lineNumber: 155
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: DbContext
+          fqdn_method: Dispose
+          fqdn_namespace: System.Data.Entity
+          symbol: db.Dispose
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+        message: |
+          System.Data.Entity is not available in .NET Core. Entity Framework 6 must be migrated to Entity Framework Core.
+
+          Migration actions:
+          - Install Microsoft.EntityFrameworkCore NuGet package
+          - Install database provider package (e.g., Microsoft.EntityFrameworkCore.SqlServer)
+          - Change using from System.Data.Entity to Microsoft.EntityFrameworkCore
+          - Review DbContext configuration - some APIs have changed
+          - Update connection string configuration (moved from Web.config to appsettings.json)
+          - Review LINQ queries - some EF6 features are not supported in EF Core
+          - Test thoroughly as EF Core has different behavior in some scenarios
+        codeSnip: " 32          private void RegisterForDinner(int id)\n 33          {\n 34              Dinner dinner = db.Dinners.Find(id);\n 35  \n 36              if (!dinner.IsUserRegistered(User.Identity.Name))\n 37              {\n 38                  RSVP rsvp = new RSVP();\n 39                  rsvp.AttendeeName = User.Identity.Name;\n 40  \n 41                  dinner.RSVPs.Add(rsvp);\n 42                  db.SaveChanges();\n 43              }\n 44          }\n 45  \n 46          //\n 47          // AJAX: /RSVP/CancelAjax/1\n 48  \n 49          [Authorize, HttpPost]\n 50          public ActionResult CancelAjax(int id)\n 51          {\n 52              Dinner dinner = db.Dinners.Find(id);"
+        lineNumber: 41
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_class: DbContext
+          fqdn_method: SaveChanges
+          fqdn_namespace: System.Data.Entity
+          symbol: db.SaveChanges
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+        message: |
+          System.Data.Entity is not available in .NET Core. Entity Framework 6 must be migrated to Entity Framework Core.
+
+          Migration actions:
+          - Install Microsoft.EntityFrameworkCore NuGet package
+          - Install database provider package (e.g., Microsoft.EntityFrameworkCore.SqlServer)
+          - Change using from System.Data.Entity to Microsoft.EntityFrameworkCore
+          - Review DbContext configuration - some APIs have changed
+          - Update connection string configuration (moved from Web.config to appsettings.json)
+          - Review LINQ queries - some EF6 features are not supported in EF Core
+          - Test thoroughly as EF Core has different behavior in some scenarios
+        codeSnip: " 48  \n 49          [Authorize, HttpPost]\n 50          public ActionResult CancelAjax(int id)\n 51          {\n 52              Dinner dinner = db.Dinners.Find(id);\n 53  \n 54              RSVP rsvp = dinner.RSVPs.SingleOrDefault(r => this.User.Identity.Name ==  r.AttendeeName);\n 55              if (rsvp != null)\n 56              {\n 57                  db.RSVPs.Remove(rsvp);\n 58                  db.SaveChanges();\n 59              }\n 60  \n 61              return Content(\"Sorry you can't make it!\");\n 62          }\n 63      }\n 64  }"
+        lineNumber: 57
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_class: DbContext
+          fqdn_method: SaveChanges
+          fqdn_namespace: System.Data.Entity
+          symbol: db.SaveChanges
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/SearchController.cs
+        message: |
+          System.Data.Entity is not available in .NET Core. Entity Framework 6 must be migrated to Entity Framework Core.
+
+          Migration actions:
+          - Install Microsoft.EntityFrameworkCore NuGet package
+          - Install database provider package (e.g., Microsoft.EntityFrameworkCore.SqlServer)
+          - Change using from System.Data.Entity to Microsoft.EntityFrameworkCore
+          - Review DbContext configuration - some APIs have changed
+          - Update connection string configuration (moved from Web.config to appsettings.json)
+          - Review LINQ queries - some EF6 features are not supported in EF Core
+          - Test thoroughly as EF Core has different behavior in some scenarios
+        codeSnip: " 98                  Longitude = dinner.Location.Longitude.Value,\n 99                  Title = dinner.Title,\n100                  Description = dinner.Description,\n101                  RSVPCount = dinner.RSVPs.Count(),\n102                  Url = dinner.DinnerID.ToString()\n103              };\n104          }\n105  \n106          protected override void Dispose(bool disposing)\n107          {\n108              db.Dispose();\n109              base.Dispose(disposing);\n110          }\n111      }\n112  }"
+        lineNumber: 107
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/SearchController.cs
+          fqdn_class: DbContext
+          fqdn_method: Dispose
+          fqdn_namespace: System.Data.Entity
+          symbol: db.Dispose
+          syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
         message: |
           System.Data.Entity is not available in .NET Core. Entity Framework 6 must be migrated to Entity Framework Core.
@@ -31,15 +420,58 @@
           - Update connection string configuration (moved from Web.config to appsettings.json)
           - Review LINQ queries - some EF6 features are not supported in EF Core
           - Test thoroughly as EF Core has different behavior in some scenarios
-        codeSnip: "17         public override void OnActionExecuting(ActionExecutingContext filterContext)\n18         {\n19             // Ensure ASP.NET Simple Membership is initialized only once per app start\n20             LazyInitializer.EnsureInitialized(ref _initializer, ref _isInitialized, ref _initializerLock);\n21         }\n22 \n23         private class SimpleMembershipInitializer\n24         {\n25             public SimpleMembershipInitializer()\n26             {\n27                 Database.SetInitializer<UsersContext>(null);\n28 \n29                 try\n30                 {\n31                     using (var context = new UsersContext())\n32                     {\n33                         if (!context.Database.Exists())\n34                         {\n35                             // Create the SimpleMembership database without Entity Framework migration schema\n36                             ((IObjectContextAdapter)context).ObjectContext.CreateDatabase();\n37                         }\n"
-        lineNumber: 27
+        codeSnip: " 24          private class SimpleMembershipInitializer\n 25          {\n 26              public SimpleMembershipInitializer()\n 27              {\n 28                  Database.SetInitializer<UsersContext>(null);\n 29  \n 30                  try\n 31                  {\n 32                      using (var context = new UsersContext())\n 33                      {\n 34                          if (!context.Database.Exists())\n 35                          {\n 36                              // Create the SimpleMembership database without Entity Framework migration schema\n 37                              ((IObjectContextAdapter)context).ObjectContext.CreateDatabase();\n 38                          }\n 39                      }\n 40  \n 41                      WebSecurity.InitializeDatabaseConnection(\"DefaultConnection\", \"UserProfile\", \"UserId\", \"UserName\", autoCreateTables: true);\n 42                  }\n 43                  catch (Exception ex)\n 44                  {"
+        lineNumber: 33
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
           fqdn_class: DbContext
           fqdn_field: Database
           fqdn_namespace: System.Data.Entity
-          symbol: Database.SetInitializer<UsersContext>
+          symbol: context.Database
           syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/AccountModels.cs
+        message: |
+          System.Data.Entity is not available in .NET Core. Entity Framework 6 must be migrated to Entity Framework Core.
+
+          Migration actions:
+          - Install Microsoft.EntityFrameworkCore NuGet package
+          - Install database provider package (e.g., Microsoft.EntityFrameworkCore.SqlServer)
+          - Change using from System.Data.Entity to Microsoft.EntityFrameworkCore
+          - Review DbContext configuration - some APIs have changed
+          - Update connection string configuration (moved from Web.config to appsettings.json)
+          - Review LINQ queries - some EF6 features are not supported in EF Core
+          - Test thoroughly as EF Core has different behavior in some scenarios
+        codeSnip: "  1  using System;\n  2  using System.Collections.Generic;\n  3  using System.ComponentModel.DataAnnotations;\n  4  using System.ComponentModel.DataAnnotations.Schema;\n  5  using System.Data.Entity;\n  6  using System.Globalization;\n  7  using System.Web.Security;\n  8  \n  9  namespace NerdDinner.Models\n 10  {\n 11      public class UsersContext : DbContext\n 12      {\n 13          public UsersContext()\n 14              : base(\"DefaultConnection\")\n 15          {\n 16          }\n 17  \n 18          public DbSet<UserProfile> UserProfiles { get; set; }\n 19      }\n 20  \n 21      [Table(\"UserProfile\")]"
+        lineNumber: 10
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/AccountModels.cs
+          fqdn_class: DbContext
+          fqdn_namespace: System.Data.Entity
+          symbol: DbContext
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/NerdDinnerContext.cs
+        message: |
+          System.Data.Entity is not available in .NET Core. Entity Framework 6 must be migrated to Entity Framework Core.
+
+          Migration actions:
+          - Install Microsoft.EntityFrameworkCore NuGet package
+          - Install database provider package (e.g., Microsoft.EntityFrameworkCore.SqlServer)
+          - Change using from System.Data.Entity to Microsoft.EntityFrameworkCore
+          - Review DbContext configuration - some APIs have changed
+          - Update connection string configuration (moved from Web.config to appsettings.json)
+          - Review LINQ queries - some EF6 features are not supported in EF Core
+          - Test thoroughly as EF Core has different behavior in some scenarios
+        codeSnip: "  1  using System.Data.Entity;\n  2  \n  3  namespace NerdDinner.Models\n  4  {\n  5      public class NerdDinnerContext : DbContext\n  6      {\n  7          // You can add custom code to this file. Changes will not be overwritten.\n  8          // \n  9          // If you want Entity Framework to drop and regenerate your database\n 10          // automatically whenever you change your model schema, add the following\n 11          // code to the Application_Start method in your Global.asax file.\n 12          // Note: this will destroy and re-create your database with every model change.\n 13          // \n 14          // System.Data.Entity.Database.SetInitializer(new System.Data.Entity.DropCreateDatabaseIfModelChanges<NerdDinner.Models.NerdDinnerContext>());\n 15  "
+        lineNumber: 4
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/NerdDinnerContext.cs
+          fqdn_class: DbContext
+          fqdn_namespace: System.Data.Entity
+          symbol: DbContext
+          syntax_type: type_reference
+        isDependencyIncident: false
       links:
       - url: https://learn.microsoft.com/en-us/ef/efcore-and-ef6/
         title: Compare EF6 and EF Core
@@ -53,6 +485,46 @@
       - konveyor.io/source=dotnet
       - konveyor.io/target=dotnet-core
       incidents:
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: "263              if (ModelState.IsValid)\n264              {\n265                  // Insert a new user into the database\n266                  using (UsersContext db = new UsersContext())\n267                  {\n268                      UserProfile user = db.UserProfiles.FirstOrDefault(u => u.UserName.ToLower() == model.UserName.ToLower());\n269                      // Check if user already exists\n270                      if (user == null)\n271                      {\n272                          // Insert name into the profile table\n273                          db.UserProfiles.Add(new UserProfile { UserName = model.UserName });\n274                          db.SaveChanges();\n275  \n276                          OAuthWebSecurity.CreateOrUpdateAccount(provider, providerUserId, model.UserName);\n277                          OAuthWebSecurity.Login(provider, providerUserId, createPersistentCookie: false);\n278  \n279                          return RedirectToLocal(returnUrl);\n280                      }\n281                      else\n282                      {\n283                          ModelState.AddModelError(\"UserName\", \"User name already exists. Please enter a different user name.\");"
+        lineNumber: 272
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: DbSet
+          fqdn_method: Add
+          fqdn_namespace: System.Data.Entity
+          symbol: UserProfiles.Add
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: "264              {\n265                  // Insert a new user into the database\n266                  using (UsersContext db = new UsersContext())\n267                  {\n268                      UserProfile user = db.UserProfiles.FirstOrDefault(u => u.UserName.ToLower() == model.UserName.ToLower());\n269                      // Check if user already exists\n270                      if (user == null)\n271                      {\n272                          // Insert name into the profile table\n273                          db.UserProfiles.Add(new UserProfile { UserName = model.UserName });\n274                          db.SaveChanges();\n275  \n276                          OAuthWebSecurity.CreateOrUpdateAccount(provider, providerUserId, model.UserName);\n277                          OAuthWebSecurity.Login(provider, providerUserId, createPersistentCookie: false);\n278  \n279                          return RedirectToLocal(returnUrl);\n280                      }\n281                      else\n282                      {\n283                          ModelState.AddModelError(\"UserName\", \"User name already exists. Please enter a different user name.\");\n284                      }"
+        lineNumber: 273
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: DbContext
+          fqdn_method: SaveChanges
+          fqdn_namespace: System.Data.Entity
+          symbol: db.SaveChanges
+          syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
         message: |
           Lazy loading works differently in EF Core and requires explicit configuration.
@@ -63,12 +535,373 @@
           - Call UseLazyLoadingProxies() in DbContext configuration
           - Or mark navigation properties as virtual and inject ILazyLoader
           - Consider using explicit loading or eager loading instead for better performance
-        codeSnip: "0 \uFEFFusing System;\n1 using System.Collections.Generic;\n2 using System.Data;\n3 using System.Data.Entity;\n4 using System.Linq;\n5 using System.Web;\n6 using System.Web.Mvc;\n7 using NerdDinner.Models;\n8 using PagedList;\n9 \n10 namespace NerdDinner.Controllers\n11 {\n12     public class DinnersController : Controller\n13     {\n"
+        codeSnip: "  1  using System;\n  2  using System.Collections.Generic;\n  3  using System.Data;\n  4  using System.Data.Entity;\n  5  using System.Linq;\n  6  using System.Web;\n  7  using System.Web.Mvc;\n  8  using NerdDinner.Models;\n  9  using PagedList;\n 10  \n 11  namespace NerdDinner.Controllers\n 12  {\n 13      public class DinnersController : Controller\n 14      {"
         lineNumber: 3
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_namespace: System.Data.Entity
           symbol: System.Data.Entity
           syntax_type: import
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: " 23  \n 24              var dinners = db.Dinners.Where(d => d.EventDate >= DateTime.Now).OrderBy(d => d.EventDate);\n 25              return View(dinners.ToPagedList(pageIndex, PageSize));\n 26          }\n 27  \n 28          //\n 29          // GET: /Dinners/Details/5\n 30  \n 31          public ActionResult Details(int id = 0)\n 32          {\n 33              Dinner dinner = db.Dinners.Find(id);\n 34              if (dinner == null)\n 35              {\n 36                  return HttpNotFound();\n 37              }\n 38              return View(dinner);\n 39          }\n 40  \n 41          //\n 42          // GET: /Dinners/Create\n 43  "
+        lineNumber: 32
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: DbSet
+          fqdn_method: Find
+          fqdn_namespace: System.Data.Entity
+          symbol: Dinners.Find
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: " 62              if (ModelState.IsValid)\n 63              {\n 64                  dinner.HostedBy = User.Identity.Name;\n 65  \n 66                  RSVP rsvp = new RSVP();\n 67                  rsvp.AttendeeName = User.Identity.Name;\n 68  \n 69                  dinner.RSVPs = new List<RSVP>();\n 70                  dinner.RSVPs.Add(rsvp);\n 71  \n 72                  db.Dinners.Add(dinner);\n 73                  db.SaveChanges();\n 74                  return RedirectToAction(\"Index\");\n 75              }\n 76  \n 77              return View(dinner);\n 78          }\n 79  \n 80          //\n 81          // GET: /Dinners/Edit/5\n 82  "
+        lineNumber: 71
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: DbSet
+          fqdn_method: Add
+          fqdn_namespace: System.Data.Entity
+          symbol: Dinners.Add
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: " 63              {\n 64                  dinner.HostedBy = User.Identity.Name;\n 65  \n 66                  RSVP rsvp = new RSVP();\n 67                  rsvp.AttendeeName = User.Identity.Name;\n 68  \n 69                  dinner.RSVPs = new List<RSVP>();\n 70                  dinner.RSVPs.Add(rsvp);\n 71  \n 72                  db.Dinners.Add(dinner);\n 73                  db.SaveChanges();\n 74                  return RedirectToAction(\"Index\");\n 75              }\n 76  \n 77              return View(dinner);\n 78          }\n 79  \n 80          //\n 81          // GET: /Dinners/Edit/5\n 82  \n 83          [Authorize]"
+        lineNumber: 72
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: DbContext
+          fqdn_method: SaveChanges
+          fqdn_namespace: System.Data.Entity
+          symbol: db.SaveChanges
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: " 76  \n 77              return View(dinner);\n 78          }\n 79  \n 80          //\n 81          // GET: /Dinners/Edit/5\n 82  \n 83          [Authorize]\n 84          public ActionResult Edit(int id = 0)\n 85          {\n 86              Dinner dinner = db.Dinners.Find(id);\n 87              if (dinner == null)\n 88              {\n 89                  return HttpNotFound();\n 90              }\n 91              if (!dinner.IsHostedBy(User.Identity.Name))\n 92              {\n 93                  return View(\"InvalidOwner\");\n 94              }\n 95              return View(dinner);\n 96          }"
+        lineNumber: 85
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: DbSet
+          fqdn_method: Find
+          fqdn_namespace: System.Data.Entity
+          symbol: Dinners.Find
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: "101          [HttpPost, Authorize, ValidateAntiForgeryToken]\n102          public ActionResult Edit(Dinner dinner)\n103          {\n104              if (!dinner.IsHostedBy(User.Identity.Name))\n105              {\n106                  return View(\"InvalidOwner\");\n107              }\n108  \n109              if (ModelState.IsValid)\n110              {\n111                  db.Entry(dinner).State = EntityState.Modified;\n112                  db.SaveChanges();\n113                  return RedirectToAction(\"Index\");\n114              }\n115              return View(dinner);\n116          }\n117  \n118          //\n119          // GET: /Dinners/Delete/5\n120  \n121          [Authorize]"
+        lineNumber: 110
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: EntityState
+          fqdn_namespace: System.Data
+          symbol: EntityState.Modified
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: "102          public ActionResult Edit(Dinner dinner)\n103          {\n104              if (!dinner.IsHostedBy(User.Identity.Name))\n105              {\n106                  return View(\"InvalidOwner\");\n107              }\n108  \n109              if (ModelState.IsValid)\n110              {\n111                  db.Entry(dinner).State = EntityState.Modified;\n112                  db.SaveChanges();\n113                  return RedirectToAction(\"Index\");\n114              }\n115              return View(dinner);\n116          }\n117  \n118          //\n119          // GET: /Dinners/Delete/5\n120  \n121          [Authorize]\n122          public ActionResult Delete(int id = 0)"
+        lineNumber: 111
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: DbContext
+          fqdn_method: SaveChanges
+          fqdn_namespace: System.Data.Entity
+          symbol: db.SaveChanges
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: "114              }\n115              return View(dinner);\n116          }\n117  \n118          //\n119          // GET: /Dinners/Delete/5\n120  \n121          [Authorize]\n122          public ActionResult Delete(int id = 0)\n123          {\n124              Dinner dinner = db.Dinners.Find(id);\n125              if (dinner == null)\n126              {\n127                  return HttpNotFound();\n128              }\n129              if (!dinner.IsHostedBy(User.Identity.Name))\n130              {\n131                  return View(\"InvalidOwner\");\n132              }\n133              return View(dinner);\n134          }"
+        lineNumber: 123
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: DbSet
+          fqdn_method: Find
+          fqdn_namespace: System.Data.Entity
+          symbol: Dinners.Find
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: "132              }\n133              return View(dinner);\n134          }\n135  \n136          //\n137          // POST: /Dinners/Delete/5\n138  \n139          [HttpPost, ActionName(\"Delete\"), Authorize, ValidateAntiForgeryToken]\n140          public ActionResult DeleteConfirmed(int id)\n141          {\n142              Dinner dinner = db.Dinners.Find(id);\n143  \n144              if (!dinner.IsHostedBy(User.Identity.Name))\n145              {\n146                  return View(\"InvalidOwner\");\n147              }\n148  \n149              db.Dinners.Remove(dinner);\n150              db.SaveChanges();\n151              return RedirectToAction(\"Index\");\n152          }"
+        lineNumber: 141
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: DbSet
+          fqdn_method: Find
+          fqdn_namespace: System.Data.Entity
+          symbol: Dinners.Find
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: "139          [HttpPost, ActionName(\"Delete\"), Authorize, ValidateAntiForgeryToken]\n140          public ActionResult DeleteConfirmed(int id)\n141          {\n142              Dinner dinner = db.Dinners.Find(id);\n143  \n144              if (!dinner.IsHostedBy(User.Identity.Name))\n145              {\n146                  return View(\"InvalidOwner\");\n147              }\n148  \n149              db.Dinners.Remove(dinner);\n150              db.SaveChanges();\n151              return RedirectToAction(\"Index\");\n152          }\n153  \n154          protected override void Dispose(bool disposing)\n155          {\n156              db.Dispose();\n157              base.Dispose(disposing);\n158          }\n159  "
+        lineNumber: 148
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: DbSet
+          fqdn_method: Remove
+          fqdn_namespace: System.Data.Entity
+          symbol: Dinners.Remove
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: "140          public ActionResult DeleteConfirmed(int id)\n141          {\n142              Dinner dinner = db.Dinners.Find(id);\n143  \n144              if (!dinner.IsHostedBy(User.Identity.Name))\n145              {\n146                  return View(\"InvalidOwner\");\n147              }\n148  \n149              db.Dinners.Remove(dinner);\n150              db.SaveChanges();\n151              return RedirectToAction(\"Index\");\n152          }\n153  \n154          protected override void Dispose(bool disposing)\n155          {\n156              db.Dispose();\n157              base.Dispose(disposing);\n158          }\n159  \n160          public ActionResult WebSlicePopular()"
+        lineNumber: 149
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: DbContext
+          fqdn_method: SaveChanges
+          fqdn_namespace: System.Data.Entity
+          symbol: db.SaveChanges
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: "146                  return View(\"InvalidOwner\");\n147              }\n148  \n149              db.Dinners.Remove(dinner);\n150              db.SaveChanges();\n151              return RedirectToAction(\"Index\");\n152          }\n153  \n154          protected override void Dispose(bool disposing)\n155          {\n156              db.Dispose();\n157              base.Dispose(disposing);\n158          }\n159  \n160          public ActionResult WebSlicePopular()\n161          {\n162              ViewData[\"Title\"] = \"Popular Nerd Dinners\";\n163              var model = from dinner in db.Dinners\n164                          where dinner.EventDate >= DateTime.Now\n165                          orderby dinner.RSVPs.Count descending\n166                          select dinner;"
+        lineNumber: 155
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: DbContext
+          fqdn_method: Dispose
+          fqdn_namespace: System.Data.Entity
+          symbol: db.Dispose
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: " 24          // AJAX: /Dinners/RegisterAjax/1\n 25          [Authorize, HttpPost]\n 26          public ActionResult RegisterAjax(int id)\n 27          {\n 28              RegisterForDinner(id);\n 29              return Content(\"Thanks - we'll see you there!\");\n 30          }\n 31  \n 32          private void RegisterForDinner(int id)\n 33          {\n 34              Dinner dinner = db.Dinners.Find(id);\n 35  \n 36              if (!dinner.IsUserRegistered(User.Identity.Name))\n 37              {\n 38                  RSVP rsvp = new RSVP();\n 39                  rsvp.AttendeeName = User.Identity.Name;\n 40  \n 41                  dinner.RSVPs.Add(rsvp);\n 42                  db.SaveChanges();\n 43              }\n 44          }"
+        lineNumber: 33
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_class: DbSet
+          fqdn_method: Find
+          fqdn_namespace: System.Data.Entity
+          symbol: Dinners.Find
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: " 32          private void RegisterForDinner(int id)\n 33          {\n 34              Dinner dinner = db.Dinners.Find(id);\n 35  \n 36              if (!dinner.IsUserRegistered(User.Identity.Name))\n 37              {\n 38                  RSVP rsvp = new RSVP();\n 39                  rsvp.AttendeeName = User.Identity.Name;\n 40  \n 41                  dinner.RSVPs.Add(rsvp);\n 42                  db.SaveChanges();\n 43              }\n 44          }\n 45  \n 46          //\n 47          // AJAX: /RSVP/CancelAjax/1\n 48  \n 49          [Authorize, HttpPost]\n 50          public ActionResult CancelAjax(int id)\n 51          {\n 52              Dinner dinner = db.Dinners.Find(id);"
+        lineNumber: 41
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_class: DbContext
+          fqdn_method: SaveChanges
+          fqdn_namespace: System.Data.Entity
+          symbol: db.SaveChanges
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: " 42                  db.SaveChanges();\n 43              }\n 44          }\n 45  \n 46          //\n 47          // AJAX: /RSVP/CancelAjax/1\n 48  \n 49          [Authorize, HttpPost]\n 50          public ActionResult CancelAjax(int id)\n 51          {\n 52              Dinner dinner = db.Dinners.Find(id);\n 53  \n 54              RSVP rsvp = dinner.RSVPs.SingleOrDefault(r => this.User.Identity.Name ==  r.AttendeeName);\n 55              if (rsvp != null)\n 56              {\n 57                  db.RSVPs.Remove(rsvp);\n 58                  db.SaveChanges();\n 59              }\n 60  \n 61              return Content(\"Sorry you can't make it!\");\n 62          }"
+        lineNumber: 51
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_class: DbSet
+          fqdn_method: Find
+          fqdn_namespace: System.Data.Entity
+          symbol: Dinners.Find
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: " 47          // AJAX: /RSVP/CancelAjax/1\n 48  \n 49          [Authorize, HttpPost]\n 50          public ActionResult CancelAjax(int id)\n 51          {\n 52              Dinner dinner = db.Dinners.Find(id);\n 53  \n 54              RSVP rsvp = dinner.RSVPs.SingleOrDefault(r => this.User.Identity.Name ==  r.AttendeeName);\n 55              if (rsvp != null)\n 56              {\n 57                  db.RSVPs.Remove(rsvp);\n 58                  db.SaveChanges();\n 59              }\n 60  \n 61              return Content(\"Sorry you can't make it!\");\n 62          }\n 63      }\n 64  }"
+        lineNumber: 56
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_class: DbSet
+          fqdn_method: Remove
+          fqdn_namespace: System.Data.Entity
+          symbol: RSVPs.Remove
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: " 48  \n 49          [Authorize, HttpPost]\n 50          public ActionResult CancelAjax(int id)\n 51          {\n 52              Dinner dinner = db.Dinners.Find(id);\n 53  \n 54              RSVP rsvp = dinner.RSVPs.SingleOrDefault(r => this.User.Identity.Name ==  r.AttendeeName);\n 55              if (rsvp != null)\n 56              {\n 57                  db.RSVPs.Remove(rsvp);\n 58                  db.SaveChanges();\n 59              }\n 60  \n 61              return Content(\"Sorry you can't make it!\");\n 62          }\n 63      }\n 64  }"
+        lineNumber: 57
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_class: DbContext
+          fqdn_method: SaveChanges
+          fqdn_namespace: System.Data.Entity
+          symbol: db.SaveChanges
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/SearchController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: " 46                  return FindByLocation(foundlocation.Lat, foundlocation.Long).\n 47                                  OrderByDescending(p => p.EventDate);\n 48              }\n 49              return null;\n 50          }\n 51  \n 52          // POST api/Search?limit=10\n 53          [HttpPost]\n 54          public IEnumerable<JsonDinner> GetMostPopularDinners(int limit)\n 55          {\n 56              var mostPopularDinners = from dinner in db.Dinners.Include(\"RSVPs\")\n 57                                       where dinner.EventDate >= DateTime.Now\n 58                                       orderby dinner.RSVPs.Count descending\n 59                                       select dinner;\n 60  \n 61              return mostPopularDinners.Take(limit).AsEnumerable().Select(item => JsonDinnerFromDinner(item));\n 62          }\n 63  \n 64          protected IQueryable<JsonDinner> FindByLocation(double latitude, double longitude)\n 65          {\n 66              var sourcePoint = DbGeography.FromText(string.Format(\"POINT ({0} {1})\", longitude, latitude));"
+        lineNumber: 55
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/SearchController.cs
+          fqdn_class: DbQuery
+          fqdn_method: Include
+          fqdn_namespace: System.Data.Entity.Infrastructure
+          symbol: Dinners.Include
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/SearchController.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: " 98                  Longitude = dinner.Location.Longitude.Value,\n 99                  Title = dinner.Title,\n100                  Description = dinner.Description,\n101                  RSVPCount = dinner.RSVPs.Count(),\n102                  Url = dinner.DinnerID.ToString()\n103              };\n104          }\n105  \n106          protected override void Dispose(bool disposing)\n107          {\n108              db.Dispose();\n109              base.Dispose(disposing);\n110          }\n111      }\n112  }"
+        lineNumber: 107
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/SearchController.cs
+          fqdn_class: DbContext
+          fqdn_method: Dispose
+          fqdn_namespace: System.Data.Entity
+          symbol: db.Dispose
+          syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
         message: |
           Lazy loading works differently in EF Core and requires explicit configuration.
@@ -79,12 +912,92 @@
           - Call UseLazyLoadingProxies() in DbContext configuration
           - Or mark navigation properties as virtual and inject ILazyLoader
           - Consider using explicit loading or eager loading instead for better performance
-        codeSnip: "0 \uFEFFusing System;\n1 using System.Data.Entity;\n2 using System.Data.Entity.Infrastructure;\n3 using System.Threading;\n4 using System.Web.Mvc;\n5 using WebMatrix.WebData;\n6 using NerdDinner.Models;\n7 \n8 namespace NerdDinner.Filters\n9 {\n10     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]\n11     public sealed class InitializeSimpleMembershipAttribute : ActionFilterAttribute\n"
+        codeSnip: "  1  using System;\n  2  using System.Data.Entity;\n  3  using System.Data.Entity.Infrastructure;\n  4  using System.Threading;\n  5  using System.Web.Mvc;\n  6  using WebMatrix.WebData;\n  7  using NerdDinner.Models;\n  8  \n  9  namespace NerdDinner.Filters\n 10  {\n 11      [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]\n 12      public sealed class InitializeSimpleMembershipAttribute : ActionFilterAttribute"
         lineNumber: 1
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
+          fqdn_namespace: System.Data.Entity
           symbol: System.Data.Entity
           syntax_type: import
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: "  1  using System;\n  2  using System.Data.Entity;\n  3  using System.Data.Entity.Infrastructure;\n  4  using System.Threading;\n  5  using System.Web.Mvc;\n  6  using WebMatrix.WebData;\n  7  using NerdDinner.Models;\n  8  \n  9  namespace NerdDinner.Filters\n 10  {\n 11      [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]\n 12      public sealed class InitializeSimpleMembershipAttribute : ActionFilterAttribute\n 13      {"
+        lineNumber: 2
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
+          fqdn_namespace: System.Data.Entity.Infrastructure
+          symbol: System.Data.Entity.Infrastructure
+          syntax_type: import
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: " 18          public override void OnActionExecuting(ActionExecutingContext filterContext)\n 19          {\n 20              // Ensure ASP.NET Simple Membership is initialized only once per app start\n 21              LazyInitializer.EnsureInitialized(ref _initializer, ref _isInitialized, ref _initializerLock);\n 22          }\n 23  \n 24          private class SimpleMembershipInitializer\n 25          {\n 26              public SimpleMembershipInitializer()\n 27              {\n 28                  Database.SetInitializer<UsersContext>(null);\n 29  \n 30                  try\n 31                  {\n 32                      using (var context = new UsersContext())\n 33                      {\n 34                          if (!context.Database.Exists())\n 35                          {\n 36                              // Create the SimpleMembership database without Entity Framework migration schema\n 37                              ((IObjectContextAdapter)context).ObjectContext.CreateDatabase();\n 38                          }"
+        lineNumber: 27
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
+          fqdn_class: Database
+          fqdn_method: SetInitializer
+          fqdn_namespace: System.Data.Entity
+          symbol: Database.SetInitializer<UsersContext>
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: " 24          private class SimpleMembershipInitializer\n 25          {\n 26              public SimpleMembershipInitializer()\n 27              {\n 28                  Database.SetInitializer<UsersContext>(null);\n 29  \n 30                  try\n 31                  {\n 32                      using (var context = new UsersContext())\n 33                      {\n 34                          if (!context.Database.Exists())\n 35                          {\n 36                              // Create the SimpleMembership database without Entity Framework migration schema\n 37                              ((IObjectContextAdapter)context).ObjectContext.CreateDatabase();\n 38                          }\n 39                      }\n 40  \n 41                      WebSecurity.InitializeDatabaseConnection(\"DefaultConnection\", \"UserProfile\", \"UserId\", \"UserName\", autoCreateTables: true);\n 42                  }\n 43                  catch (Exception ex)\n 44                  {"
+        lineNumber: 33
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
+          fqdn_class: Database
+          fqdn_method: Exists
+          fqdn_namespace: System.Data.Entity
+          symbol: Database.Exists
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: " 27              {\n 28                  Database.SetInitializer<UsersContext>(null);\n 29  \n 30                  try\n 31                  {\n 32                      using (var context = new UsersContext())\n 33                      {\n 34                          if (!context.Database.Exists())\n 35                          {\n 36                              // Create the SimpleMembership database without Entity Framework migration schema\n 37                              ((IObjectContextAdapter)context).ObjectContext.CreateDatabase();\n 38                          }\n 39                      }\n 40  \n 41                      WebSecurity.InitializeDatabaseConnection(\"DefaultConnection\", \"UserProfile\", \"UserId\", \"UserName\", autoCreateTables: true);\n 42                  }\n 43                  catch (Exception ex)\n 44                  {\n 45                      throw new InvalidOperationException(\"The ASP.NET Simple Membership database could not be initialized. For more information, please see http://go.microsoft.com/fwlink/?LinkId=256588\", ex);\n 46                  }\n 47              }"
+        lineNumber: 36
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
+          fqdn_class: IObjectContextAdapter
+          fqdn_field: ObjectContext
+          fqdn_namespace: System.Data.Entity.Infrastructure
+          symbol: ((IObjectContextAdapter)context).ObjectContext
+          syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/AccountModels.cs
         message: |
           Lazy loading works differently in EF Core and requires explicit configuration.
@@ -95,12 +1008,52 @@
           - Call UseLazyLoadingProxies() in DbContext configuration
           - Or mark navigation properties as virtual and inject ILazyLoader
           - Consider using explicit loading or eager loading instead for better performance
-        codeSnip: "0 \uFEFFusing System;\n1 using System.Collections.Generic;\n2 using System.ComponentModel.DataAnnotations;\n3 using System.ComponentModel.DataAnnotations.Schema;\n4 using System.Data.Entity;\n5 using System.Globalization;\n6 using System.Web.Security;\n7 \n8 namespace NerdDinner.Models\n9 {\n10     public class UsersContext : DbContext\n11     {\n12         public UsersContext()\n13             : base(\"DefaultConnection\")\n14         {\n"
+        codeSnip: "  1  using System;\n  2  using System.Collections.Generic;\n  3  using System.ComponentModel.DataAnnotations;\n  4  using System.ComponentModel.DataAnnotations.Schema;\n  5  using System.Data.Entity;\n  6  using System.Globalization;\n  7  using System.Web.Security;\n  8  \n  9  namespace NerdDinner.Models\n 10  {\n 11      public class UsersContext : DbContext\n 12      {\n 13          public UsersContext()\n 14              : base(\"DefaultConnection\")\n 15          {"
         lineNumber: 4
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/AccountModels.cs
+          fqdn_namespace: System.Data.Entity
           symbol: System.Data.Entity
           syntax_type: import
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/AccountModels.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: "  1  using System;\n  2  using System.Collections.Generic;\n  3  using System.ComponentModel.DataAnnotations;\n  4  using System.ComponentModel.DataAnnotations.Schema;\n  5  using System.Data.Entity;\n  6  using System.Globalization;\n  7  using System.Web.Security;\n  8  \n  9  namespace NerdDinner.Models\n 10  {\n 11      public class UsersContext : DbContext\n 12      {\n 13          public UsersContext()\n 14              : base(\"DefaultConnection\")\n 15          {\n 16          }\n 17  \n 18          public DbSet<UserProfile> UserProfiles { get; set; }\n 19      }\n 20  \n 21      [Table(\"UserProfile\")]"
+        lineNumber: 10
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/AccountModels.cs
+          fqdn_class: DbContext
+          fqdn_namespace: System.Data.Entity
+          symbol: DbContext
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/AccountModels.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: "  8  \n  9  namespace NerdDinner.Models\n 10  {\n 11      public class UsersContext : DbContext\n 12      {\n 13          public UsersContext()\n 14              : base(\"DefaultConnection\")\n 15          {\n 16          }\n 17  \n 18          public DbSet<UserProfile> UserProfiles { get; set; }\n 19      }\n 20  \n 21      [Table(\"UserProfile\")]\n 22      public class UserProfile\n 23      {\n 24          [Key]\n 25          [DatabaseGeneratedAttribute(DatabaseGeneratedOption.Identity)]\n 26          public int UserId { get; set; }\n 27          public string UserName { get; set; }\n 28      }"
+        lineNumber: 17
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/AccountModels.cs
+          fqdn_class: DbSet
+          fqdn_namespace: System.Data.Entity
+          symbol: DbSet<UserProfile>
+          syntax_type: type_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/NerdDinnerContext.cs
         message: |
           Lazy loading works differently in EF Core and requires explicit configuration.
@@ -111,16 +1064,354 @@
           - Call UseLazyLoadingProxies() in DbContext configuration
           - Or mark navigation properties as virtual and inject ILazyLoader
           - Consider using explicit loading or eager loading instead for better performance
-        codeSnip: "0 \uFEFFusing System.Data.Entity;\n1 \n2 namespace NerdDinner.Models\n3 {\n4     public class NerdDinnerContext : DbContext\n5     {\n6         // You can add custom code to this file. Changes will not be overwritten.\n7         // \n8         // If you want Entity Framework to drop and regenerate your database\n9         // automatically whenever you change your model schema, add the following\n10         // code to the Application_Start method in your Global.asax file.\n"
+        codeSnip: "  1  using System.Data.Entity;\n  2  \n  3  namespace NerdDinner.Models\n  4  {\n  5      public class NerdDinnerContext : DbContext\n  6      {\n  7          // You can add custom code to this file. Changes will not be overwritten.\n  8          // \n  9          // If you want Entity Framework to drop and regenerate your database\n 10          // automatically whenever you change your model schema, add the following\n 11          // code to the Application_Start method in your Global.asax file."
         lineNumber: 0
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/NerdDinnerContext.cs
+          fqdn_namespace: System.Data.Entity
           symbol: System.Data.Entity
           syntax_type: import
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/NerdDinnerContext.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: "  1  using System.Data.Entity;\n  2  \n  3  namespace NerdDinner.Models\n  4  {\n  5      public class NerdDinnerContext : DbContext\n  6      {\n  7          // You can add custom code to this file. Changes will not be overwritten.\n  8          // \n  9          // If you want Entity Framework to drop and regenerate your database\n 10          // automatically whenever you change your model schema, add the following\n 11          // code to the Application_Start method in your Global.asax file.\n 12          // Note: this will destroy and re-create your database with every model change.\n 13          // \n 14          // System.Data.Entity.Database.SetInitializer(new System.Data.Entity.DropCreateDatabaseIfModelChanges<NerdDinner.Models.NerdDinnerContext>());\n 15  "
+        lineNumber: 4
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/NerdDinnerContext.cs
+          fqdn_class: DbContext
+          fqdn_namespace: System.Data.Entity
+          symbol: DbContext
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/NerdDinnerContext.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: " 10          // automatically whenever you change your model schema, add the following\n 11          // code to the Application_Start method in your Global.asax file.\n 12          // Note: this will destroy and re-create your database with every model change.\n 13          // \n 14          // System.Data.Entity.Database.SetInitializer(new System.Data.Entity.DropCreateDatabaseIfModelChanges<NerdDinner.Models.NerdDinnerContext>());\n 15  \n 16          public NerdDinnerContext() : base(\"name=NerdDinnerContext\")\n 17          {\n 18          }\n 19  \n 20          public DbSet<Dinner> Dinners { get; set; }\n 21          public DbSet<RSVP> RSVPs { get; set; }\n 22      }\n 23  }"
+        lineNumber: 19
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/NerdDinnerContext.cs
+          fqdn_class: DbSet
+          fqdn_namespace: System.Data.Entity
+          symbol: DbSet<Dinner>
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/NerdDinnerContext.cs
+        message: |
+          Lazy loading works differently in EF Core and requires explicit configuration.
+
+          Review actions:
+          - Lazy loading is opt-in in EF Core (was default in EF6)
+          - Add Microsoft.EntityFrameworkCore.Proxies for lazy loading support
+          - Call UseLazyLoadingProxies() in DbContext configuration
+          - Or mark navigation properties as virtual and inject ILazyLoader
+          - Consider using explicit loading or eager loading instead for better performance
+        codeSnip: " 11          // code to the Application_Start method in your Global.asax file.\n 12          // Note: this will destroy and re-create your database with every model change.\n 13          // \n 14          // System.Data.Entity.Database.SetInitializer(new System.Data.Entity.DropCreateDatabaseIfModelChanges<NerdDinner.Models.NerdDinnerContext>());\n 15  \n 16          public NerdDinnerContext() : base(\"name=NerdDinnerContext\")\n 17          {\n 18          }\n 19  \n 20          public DbSet<Dinner> Dinners { get; set; }\n 21          public DbSet<RSVP> RSVPs { get; set; }\n 22      }\n 23  }"
+        lineNumber: 20
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/NerdDinnerContext.cs
+          fqdn_class: DbSet
+          fqdn_namespace: System.Data.Entity
+          symbol: DbSet<RSVP>
+          syntax_type: type_reference
+        isDependencyIncident: false
       links:
       - url: https://learn.microsoft.com/en-us/ef/core/querying/related-data/lazy
         title: Lazy loading in EF Core
       effort: 3
+    dotnet-core-httpapplication-01:
+      description: System.Web.HttpApplication base class not available in .NET Core
+      category: mandatory
+      labels:
+      - konveyor.io/source=dotnet
+      - konveyor.io/target=dotnet-core
+      incidents:
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
+        message: |
+          System.Web.HttpApplication is not available in .NET Core.
+          Global.asax and the HttpApplication class are replaced by the Startup class and Program.cs in ASP.NET Core.
+
+          Migration actions:
+          - Create a Startup.cs class with Configure and ConfigureServices methods
+          - Move Application_Start logic to Configure method
+          - Move dependency registration to ConfigureServices method
+          - Use middleware pipeline instead of HTTP modules and handlers
+        codeSnip: "  6  using System.Web.Http;\n  7  using System.Web.Mvc;\n  8  using System.Web.Optimization;\n  9  using System.Web.Routing;\n 10  \n 11  namespace NerdDinner\n 12  {\n 13      // Note: For instructions on enabling IIS6 or IIS7 classic mode, \n 14      // visit http://go.microsoft.com/?LinkId=9394801\n 15  \n 16      public class MvcApplication : System.Web.HttpApplication\n 17      {\n 18          protected void Application_Start()\n 19          {\n 20              AreaRegistration.RegisterAllAreas();\n 21  \n 22              WebApiConfig.Register(GlobalConfiguration.Configuration);\n 23              FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);\n 24              RouteConfig.RegisterRoutes(RouteTable.Routes);\n 25              BundleConfig.RegisterBundles(BundleTable.Bundles);\n 26              AuthConfig.RegisterAuth();"
+        lineNumber: 15
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
+          fqdn_class: HttpApplication
+          fqdn_namespace: System.Web
+          symbol: HttpApplication
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
+        message: |
+          System.Web.HttpApplication is not available in .NET Core.
+          Global.asax and the HttpApplication class are replaced by the Startup class and Program.cs in ASP.NET Core.
+
+          Migration actions:
+          - Create a Startup.cs class with Configure and ConfigureServices methods
+          - Move Application_Start logic to Configure method
+          - Move dependency registration to ConfigureServices method
+          - Use middleware pipeline instead of HTTP modules and handlers
+        codeSnip: " 21  \n 22              WebApiConfig.Register(GlobalConfiguration.Configuration);\n 23              FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);\n 24              RouteConfig.RegisterRoutes(RouteTable.Routes);\n 25              BundleConfig.RegisterBundles(BundleTable.Bundles);\n 26              AuthConfig.RegisterAuth();\n 27  \n 28              ModelBinderProviders.BinderProviders.Add(new EFModelBinderProvider());\n 29  \n 30              Version version = Assembly.GetExecutingAssembly().GetName().Version;\n 31              Application[\"Version\"] = string.Format(\"{0}.{1}\", version.Major, version.Minor);\n 32          }\n 33      }\n 34  }"
+        lineNumber: 30
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
+          fqdn_class: HttpApplication
+          fqdn_field: Application
+          fqdn_namespace: System.Web
+          symbol: Application
+          syntax_type: field_reference
+        isDependencyIncident: false
+      links:
+      - url: https://learn.microsoft.com/en-us/aspnet/core/fundamentals/startup
+        title: App startup in ASP.NET Core
+      effort: 5
+    dotnet-core-membership-01:
+      description: System.Web.Security.Membership is not available in .NET Core
+      category: mandatory
+      labels:
+      - konveyor.io/source=dotnet
+      - konveyor.io/target=dotnet-core
+      incidents:
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          System.Web.Security.Membership is not available in .NET Core and must be replaced with ASP.NET Core Identity.
+
+          Migration actions:
+          - Replace Membership provider with ASP.NET Core Identity UserManager
+          - Update membership-related code to use UserManager methods
+          - Replace MembershipCreateUserException with IdentityResult error handling
+          - Configure password policies using IdentityOptions in Startup
+          - Migrate membership database schema to Identity schema
+        codeSnip: " 78              {\n 79                  // Attempt to register the user\n 80                  try\n 81                  {\n 82                      WebSecurity.CreateUserAndAccount(model.UserName, model.Password);\n 83                      WebSecurity.Login(model.UserName, model.Password);\n 84                      return RedirectToAction(\"Index\", \"Home\");\n 85                  }\n 86                  catch (MembershipCreateUserException e)\n 87                  {\n 88                      ModelState.AddModelError(\"\", ErrorCodeToString(e.StatusCode));\n 89                  }\n 90              }\n 91  \n 92              // If we got this far, something failed, redisplay form\n 93              return View(model);\n 94          }\n 95  \n 96          //\n 97          // POST: /Account/Disassociate\n 98  "
+        lineNumber: 87
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: MembershipCreateStatus
+          fqdn_namespace: System.Web.Security
+          symbol: e.StatusCode
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          System.Web.Security.Membership is not available in .NET Core and must be replaced with ASP.NET Core Identity.
+
+          Migration actions:
+          - Replace Membership provider with ASP.NET Core Identity UserManager
+          - Update membership-related code to use UserManager methods
+          - Replace MembershipCreateUserException with IdentityResult error handling
+          - Configure password policies using IdentityOptions in Startup
+          - Migrate membership database schema to Identity schema
+        codeSnip: "358  \n359              public string Provider { get; private set; }\n360              public string ReturnUrl { get; private set; }\n361  \n362              public override void ExecuteResult(ControllerContext context)\n363              {\n364                  OAuthWebSecurity.RequestAuthentication(Provider, ReturnUrl);\n365              }\n366          }\n367  \n368          private static string ErrorCodeToString(MembershipCreateStatus createStatus)\n369          {\n370              // See http://go.microsoft.com/fwlink/?LinkID=177550 for\n371              // a full list of status codes.\n372              switch (createStatus)\n373              {\n374                  case MembershipCreateStatus.DuplicateUserName:\n375                      return \"User name already exists. Please enter a different user name.\";\n376  \n377                  case MembershipCreateStatus.DuplicateEmail:\n378                      return \"A user name for that e-mail address already exists. Please enter a different e-mail address.\";"
+        lineNumber: 367
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: MembershipCreateStatus
+          fqdn_namespace: System.Web.Security
+          symbol: MembershipCreateStatus
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          System.Web.Security.Membership is not available in .NET Core and must be replaced with ASP.NET Core Identity.
+
+          Migration actions:
+          - Replace Membership provider with ASP.NET Core Identity UserManager
+          - Update membership-related code to use UserManager methods
+          - Replace MembershipCreateUserException with IdentityResult error handling
+          - Configure password policies using IdentityOptions in Startup
+          - Migrate membership database schema to Identity schema
+        codeSnip: "364                  OAuthWebSecurity.RequestAuthentication(Provider, ReturnUrl);\n365              }\n366          }\n367  \n368          private static string ErrorCodeToString(MembershipCreateStatus createStatus)\n369          {\n370              // See http://go.microsoft.com/fwlink/?LinkID=177550 for\n371              // a full list of status codes.\n372              switch (createStatus)\n373              {\n374                  case MembershipCreateStatus.DuplicateUserName:\n375                      return \"User name already exists. Please enter a different user name.\";\n376  \n377                  case MembershipCreateStatus.DuplicateEmail:\n378                      return \"A user name for that e-mail address already exists. Please enter a different e-mail address.\";\n379  \n380                  case MembershipCreateStatus.InvalidPassword:\n381                      return \"The password provided is invalid. Please enter a valid password value.\";\n382  \n383                  case MembershipCreateStatus.InvalidEmail:\n384                      return \"The e-mail address provided is invalid. Please check the value and try again.\";"
+        lineNumber: 373
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: MembershipCreateStatus
+          fqdn_field: DuplicateUserName
+          fqdn_namespace: System.Web.Security
+          symbol: MembershipCreateStatus.DuplicateUserName
+          syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          System.Web.Security.Membership is not available in .NET Core and must be replaced with ASP.NET Core Identity.
+
+          Migration actions:
+          - Replace Membership provider with ASP.NET Core Identity UserManager
+          - Update membership-related code to use UserManager methods
+          - Replace MembershipCreateUserException with IdentityResult error handling
+          - Configure password policies using IdentityOptions in Startup
+          - Migrate membership database schema to Identity schema
+        codeSnip: "367  \n368          private static string ErrorCodeToString(MembershipCreateStatus createStatus)\n369          {\n370              // See http://go.microsoft.com/fwlink/?LinkID=177550 for\n371              // a full list of status codes.\n372              switch (createStatus)\n373              {\n374                  case MembershipCreateStatus.DuplicateUserName:\n375                      return \"User name already exists. Please enter a different user name.\";\n376  \n377                  case MembershipCreateStatus.DuplicateEmail:\n378                      return \"A user name for that e-mail address already exists. Please enter a different e-mail address.\";\n379  \n380                  case MembershipCreateStatus.InvalidPassword:\n381                      return \"The password provided is invalid. Please enter a valid password value.\";\n382  \n383                  case MembershipCreateStatus.InvalidEmail:\n384                      return \"The e-mail address provided is invalid. Please check the value and try again.\";\n385  \n386                  case MembershipCreateStatus.InvalidAnswer:\n387                      return \"The password retrieval answer provided is invalid. Please check the value and try again.\";"
+        lineNumber: 376
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: MembershipCreateStatus
+          fqdn_field: DuplicateEmail
+          fqdn_namespace: System.Web.Security
+          symbol: MembershipCreateStatus.DuplicateEmail
+          syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          System.Web.Security.Membership is not available in .NET Core and must be replaced with ASP.NET Core Identity.
+
+          Migration actions:
+          - Replace Membership provider with ASP.NET Core Identity UserManager
+          - Update membership-related code to use UserManager methods
+          - Replace MembershipCreateUserException with IdentityResult error handling
+          - Configure password policies using IdentityOptions in Startup
+          - Migrate membership database schema to Identity schema
+        codeSnip: "370              // See http://go.microsoft.com/fwlink/?LinkID=177550 for\n371              // a full list of status codes.\n372              switch (createStatus)\n373              {\n374                  case MembershipCreateStatus.DuplicateUserName:\n375                      return \"User name already exists. Please enter a different user name.\";\n376  \n377                  case MembershipCreateStatus.DuplicateEmail:\n378                      return \"A user name for that e-mail address already exists. Please enter a different e-mail address.\";\n379  \n380                  case MembershipCreateStatus.InvalidPassword:\n381                      return \"The password provided is invalid. Please enter a valid password value.\";\n382  \n383                  case MembershipCreateStatus.InvalidEmail:\n384                      return \"The e-mail address provided is invalid. Please check the value and try again.\";\n385  \n386                  case MembershipCreateStatus.InvalidAnswer:\n387                      return \"The password retrieval answer provided is invalid. Please check the value and try again.\";\n388  \n389                  case MembershipCreateStatus.InvalidQuestion:\n390                      return \"The password retrieval question provided is invalid. Please check the value and try again.\";"
+        lineNumber: 379
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: MembershipCreateStatus
+          fqdn_field: InvalidPassword
+          fqdn_namespace: System.Web.Security
+          symbol: MembershipCreateStatus.InvalidPassword
+          syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          System.Web.Security.Membership is not available in .NET Core and must be replaced with ASP.NET Core Identity.
+
+          Migration actions:
+          - Replace Membership provider with ASP.NET Core Identity UserManager
+          - Update membership-related code to use UserManager methods
+          - Replace MembershipCreateUserException with IdentityResult error handling
+          - Configure password policies using IdentityOptions in Startup
+          - Migrate membership database schema to Identity schema
+        codeSnip: "373              {\n374                  case MembershipCreateStatus.DuplicateUserName:\n375                      return \"User name already exists. Please enter a different user name.\";\n376  \n377                  case MembershipCreateStatus.DuplicateEmail:\n378                      return \"A user name for that e-mail address already exists. Please enter a different e-mail address.\";\n379  \n380                  case MembershipCreateStatus.InvalidPassword:\n381                      return \"The password provided is invalid. Please enter a valid password value.\";\n382  \n383                  case MembershipCreateStatus.InvalidEmail:\n384                      return \"The e-mail address provided is invalid. Please check the value and try again.\";\n385  \n386                  case MembershipCreateStatus.InvalidAnswer:\n387                      return \"The password retrieval answer provided is invalid. Please check the value and try again.\";\n388  \n389                  case MembershipCreateStatus.InvalidQuestion:\n390                      return \"The password retrieval question provided is invalid. Please check the value and try again.\";\n391  \n392                  case MembershipCreateStatus.InvalidUserName:\n393                      return \"The user name provided is invalid. Please check the value and try again.\";"
+        lineNumber: 382
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: MembershipCreateStatus
+          fqdn_field: InvalidEmail
+          fqdn_namespace: System.Web.Security
+          symbol: MembershipCreateStatus.InvalidEmail
+          syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          System.Web.Security.Membership is not available in .NET Core and must be replaced with ASP.NET Core Identity.
+
+          Migration actions:
+          - Replace Membership provider with ASP.NET Core Identity UserManager
+          - Update membership-related code to use UserManager methods
+          - Replace MembershipCreateUserException with IdentityResult error handling
+          - Configure password policies using IdentityOptions in Startup
+          - Migrate membership database schema to Identity schema
+        codeSnip: "376  \n377                  case MembershipCreateStatus.DuplicateEmail:\n378                      return \"A user name for that e-mail address already exists. Please enter a different e-mail address.\";\n379  \n380                  case MembershipCreateStatus.InvalidPassword:\n381                      return \"The password provided is invalid. Please enter a valid password value.\";\n382  \n383                  case MembershipCreateStatus.InvalidEmail:\n384                      return \"The e-mail address provided is invalid. Please check the value and try again.\";\n385  \n386                  case MembershipCreateStatus.InvalidAnswer:\n387                      return \"The password retrieval answer provided is invalid. Please check the value and try again.\";\n388  \n389                  case MembershipCreateStatus.InvalidQuestion:\n390                      return \"The password retrieval question provided is invalid. Please check the value and try again.\";\n391  \n392                  case MembershipCreateStatus.InvalidUserName:\n393                      return \"The user name provided is invalid. Please check the value and try again.\";\n394  \n395                  case MembershipCreateStatus.ProviderError:\n396                      return \"The authentication provider returned an error. Please verify your entry and try again. If the problem persists, please contact your system administrator.\";"
+        lineNumber: 385
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: MembershipCreateStatus
+          fqdn_field: InvalidAnswer
+          fqdn_namespace: System.Web.Security
+          symbol: MembershipCreateStatus.InvalidAnswer
+          syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          System.Web.Security.Membership is not available in .NET Core and must be replaced with ASP.NET Core Identity.
+
+          Migration actions:
+          - Replace Membership provider with ASP.NET Core Identity UserManager
+          - Update membership-related code to use UserManager methods
+          - Replace MembershipCreateUserException with IdentityResult error handling
+          - Configure password policies using IdentityOptions in Startup
+          - Migrate membership database schema to Identity schema
+        codeSnip: "379  \n380                  case MembershipCreateStatus.InvalidPassword:\n381                      return \"The password provided is invalid. Please enter a valid password value.\";\n382  \n383                  case MembershipCreateStatus.InvalidEmail:\n384                      return \"The e-mail address provided is invalid. Please check the value and try again.\";\n385  \n386                  case MembershipCreateStatus.InvalidAnswer:\n387                      return \"The password retrieval answer provided is invalid. Please check the value and try again.\";\n388  \n389                  case MembershipCreateStatus.InvalidQuestion:\n390                      return \"The password retrieval question provided is invalid. Please check the value and try again.\";\n391  \n392                  case MembershipCreateStatus.InvalidUserName:\n393                      return \"The user name provided is invalid. Please check the value and try again.\";\n394  \n395                  case MembershipCreateStatus.ProviderError:\n396                      return \"The authentication provider returned an error. Please verify your entry and try again. If the problem persists, please contact your system administrator.\";\n397  \n398                  case MembershipCreateStatus.UserRejected:\n399                      return \"The user creation request has been canceled. Please verify your entry and try again. If the problem persists, please contact your system administrator.\";"
+        lineNumber: 388
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: MembershipCreateStatus
+          fqdn_field: InvalidQuestion
+          fqdn_namespace: System.Web.Security
+          symbol: MembershipCreateStatus.InvalidQuestion
+          syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          System.Web.Security.Membership is not available in .NET Core and must be replaced with ASP.NET Core Identity.
+
+          Migration actions:
+          - Replace Membership provider with ASP.NET Core Identity UserManager
+          - Update membership-related code to use UserManager methods
+          - Replace MembershipCreateUserException with IdentityResult error handling
+          - Configure password policies using IdentityOptions in Startup
+          - Migrate membership database schema to Identity schema
+        codeSnip: "382  \n383                  case MembershipCreateStatus.InvalidEmail:\n384                      return \"The e-mail address provided is invalid. Please check the value and try again.\";\n385  \n386                  case MembershipCreateStatus.InvalidAnswer:\n387                      return \"The password retrieval answer provided is invalid. Please check the value and try again.\";\n388  \n389                  case MembershipCreateStatus.InvalidQuestion:\n390                      return \"The password retrieval question provided is invalid. Please check the value and try again.\";\n391  \n392                  case MembershipCreateStatus.InvalidUserName:\n393                      return \"The user name provided is invalid. Please check the value and try again.\";\n394  \n395                  case MembershipCreateStatus.ProviderError:\n396                      return \"The authentication provider returned an error. Please verify your entry and try again. If the problem persists, please contact your system administrator.\";\n397  \n398                  case MembershipCreateStatus.UserRejected:\n399                      return \"The user creation request has been canceled. Please verify your entry and try again. If the problem persists, please contact your system administrator.\";\n400  \n401                  default:\n402                      return \"An unknown error occurred. Please verify your entry and try again. If the problem persists, please contact your system administrator.\";"
+        lineNumber: 391
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: MembershipCreateStatus
+          fqdn_field: InvalidUserName
+          fqdn_namespace: System.Web.Security
+          symbol: MembershipCreateStatus.InvalidUserName
+          syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          System.Web.Security.Membership is not available in .NET Core and must be replaced with ASP.NET Core Identity.
+
+          Migration actions:
+          - Replace Membership provider with ASP.NET Core Identity UserManager
+          - Update membership-related code to use UserManager methods
+          - Replace MembershipCreateUserException with IdentityResult error handling
+          - Configure password policies using IdentityOptions in Startup
+          - Migrate membership database schema to Identity schema
+        codeSnip: "385  \n386                  case MembershipCreateStatus.InvalidAnswer:\n387                      return \"The password retrieval answer provided is invalid. Please check the value and try again.\";\n388  \n389                  case MembershipCreateStatus.InvalidQuestion:\n390                      return \"The password retrieval question provided is invalid. Please check the value and try again.\";\n391  \n392                  case MembershipCreateStatus.InvalidUserName:\n393                      return \"The user name provided is invalid. Please check the value and try again.\";\n394  \n395                  case MembershipCreateStatus.ProviderError:\n396                      return \"The authentication provider returned an error. Please verify your entry and try again. If the problem persists, please contact your system administrator.\";\n397  \n398                  case MembershipCreateStatus.UserRejected:\n399                      return \"The user creation request has been canceled. Please verify your entry and try again. If the problem persists, please contact your system administrator.\";\n400  \n401                  default:\n402                      return \"An unknown error occurred. Please verify your entry and try again. If the problem persists, please contact your system administrator.\";\n403              }\n404          }\n405          #endregion"
+        lineNumber: 394
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: MembershipCreateStatus
+          fqdn_field: ProviderError
+          fqdn_namespace: System.Web.Security
+          symbol: MembershipCreateStatus.ProviderError
+          syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          System.Web.Security.Membership is not available in .NET Core and must be replaced with ASP.NET Core Identity.
+
+          Migration actions:
+          - Replace Membership provider with ASP.NET Core Identity UserManager
+          - Update membership-related code to use UserManager methods
+          - Replace MembershipCreateUserException with IdentityResult error handling
+          - Configure password policies using IdentityOptions in Startup
+          - Migrate membership database schema to Identity schema
+        codeSnip: "388  \n389                  case MembershipCreateStatus.InvalidQuestion:\n390                      return \"The password retrieval question provided is invalid. Please check the value and try again.\";\n391  \n392                  case MembershipCreateStatus.InvalidUserName:\n393                      return \"The user name provided is invalid. Please check the value and try again.\";\n394  \n395                  case MembershipCreateStatus.ProviderError:\n396                      return \"The authentication provider returned an error. Please verify your entry and try again. If the problem persists, please contact your system administrator.\";\n397  \n398                  case MembershipCreateStatus.UserRejected:\n399                      return \"The user creation request has been canceled. Please verify your entry and try again. If the problem persists, please contact your system administrator.\";\n400  \n401                  default:\n402                      return \"An unknown error occurred. Please verify your entry and try again. If the problem persists, please contact your system administrator.\";\n403              }\n404          }\n405          #endregion\n406      }\n407  }"
+        lineNumber: 397
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: MembershipCreateStatus
+          fqdn_field: UserRejected
+          fqdn_namespace: System.Web.Security
+          symbol: MembershipCreateStatus.UserRejected
+          syntax_type: field_reference
+        isDependencyIncident: false
+      links:
+      - url: https://learn.microsoft.com/en-us/aspnet/core/migration/identity
+        title: Migrate from ASP.NET membership to ASP.NET Core Identity
+      effort: 7
     dotnet-core-oauth-01:
       description: Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core
       category: mandatory
@@ -141,7 +1432,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "11     {\n12         public static void RegisterAuth()\n13         {\n14             // To let users of this site log in using their accounts from other sites such as Microsoft, Facebook, and Twitter,\n15             // you must update this site. For more information visit http://go.microsoft.com/fwlink/?LinkID=252166\n16 \n17             var microsoftClientId = WebConfigurationManager.AppSettings[\"microsoftClientId\"];\n18             var microsoftClientSecret = WebConfigurationManager.AppSettings[\"microsoftClientSecret\"];\n19             if (!string.IsNullOrEmpty(microsoftClientId) && !string.IsNullOrEmpty(microsoftClientSecret))\n20             {\n21                 OAuthWebSecurity.RegisterMicrosoftClient(\n22                     clientId: microsoftClientId,\n23                     clientSecret: microsoftClientSecret);\n24             }\n25 \n26             var twitterConsumerKey = WebConfigurationManager.AppSettings[\"twitterConsumerKey\"];\n27             var twitterConsumerSecret = WebConfigurationManager.AppSettings[\"twitterConsumerSecret\"];\n28             if (!string.IsNullOrEmpty(twitterConsumerKey) && !string.IsNullOrEmpty(twitterConsumerSecret))\n29             {\n30                 OAuthWebSecurity.RegisterTwitterClient(\n31                     consumerKey: twitterConsumerKey,\n"
+        codeSnip: " 12      {\n 13          public static void RegisterAuth()\n 14          {\n 15              // To let users of this site log in using their accounts from other sites such as Microsoft, Facebook, and Twitter,\n 16              // you must update this site. For more information visit http://go.microsoft.com/fwlink/?LinkID=252166\n 17  \n 18              var microsoftClientId = WebConfigurationManager.AppSettings[\"microsoftClientId\"];\n 19              var microsoftClientSecret = WebConfigurationManager.AppSettings[\"microsoftClientSecret\"];\n 20              if (!string.IsNullOrEmpty(microsoftClientId) && !string.IsNullOrEmpty(microsoftClientSecret))\n 21              {\n 22                  OAuthWebSecurity.RegisterMicrosoftClient(\n 23                      clientId: microsoftClientId,\n 24                      clientSecret: microsoftClientSecret);\n 25              }\n 26  \n 27              var twitterConsumerKey = WebConfigurationManager.AppSettings[\"twitterConsumerKey\"];\n 28              var twitterConsumerSecret = WebConfigurationManager.AppSettings[\"twitterConsumerSecret\"];\n 29              if (!string.IsNullOrEmpty(twitterConsumerKey) && !string.IsNullOrEmpty(twitterConsumerSecret))\n 30              {\n 31                  OAuthWebSecurity.RegisterTwitterClient(\n 32                      consumerKey: twitterConsumerKey,"
         lineNumber: 21
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
@@ -150,6 +1441,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.RegisterMicrosoftClient
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -163,7 +1455,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "20             {\n21                 OAuthWebSecurity.RegisterMicrosoftClient(\n22                     clientId: microsoftClientId,\n23                     clientSecret: microsoftClientSecret);\n24             }\n25 \n26             var twitterConsumerKey = WebConfigurationManager.AppSettings[\"twitterConsumerKey\"];\n27             var twitterConsumerSecret = WebConfigurationManager.AppSettings[\"twitterConsumerSecret\"];\n28             if (!string.IsNullOrEmpty(twitterConsumerKey) && !string.IsNullOrEmpty(twitterConsumerSecret))\n29             {\n30                 OAuthWebSecurity.RegisterTwitterClient(\n31                     consumerKey: twitterConsumerKey,\n32                     consumerSecret: twitterConsumerSecret);\n33             }\n34 \n35             var facebookAppId = WebConfigurationManager.AppSettings[\"facebookAppId\"];\n36             var facebookAppSecret = WebConfigurationManager.AppSettings[\"facebookAppSecret\"];\n37             if (!string.IsNullOrEmpty(facebookAppId) && !string.IsNullOrEmpty(facebookAppSecret))\n38             {\n39                 OAuthWebSecurity.RegisterFacebookClient(\n40                     appId: facebookAppId,\n"
+        codeSnip: " 21              {\n 22                  OAuthWebSecurity.RegisterMicrosoftClient(\n 23                      clientId: microsoftClientId,\n 24                      clientSecret: microsoftClientSecret);\n 25              }\n 26  \n 27              var twitterConsumerKey = WebConfigurationManager.AppSettings[\"twitterConsumerKey\"];\n 28              var twitterConsumerSecret = WebConfigurationManager.AppSettings[\"twitterConsumerSecret\"];\n 29              if (!string.IsNullOrEmpty(twitterConsumerKey) && !string.IsNullOrEmpty(twitterConsumerSecret))\n 30              {\n 31                  OAuthWebSecurity.RegisterTwitterClient(\n 32                      consumerKey: twitterConsumerKey,\n 33                      consumerSecret: twitterConsumerSecret);\n 34              }\n 35  \n 36              var facebookAppId = WebConfigurationManager.AppSettings[\"facebookAppId\"];\n 37              var facebookAppSecret = WebConfigurationManager.AppSettings[\"facebookAppSecret\"];\n 38              if (!string.IsNullOrEmpty(facebookAppId) && !string.IsNullOrEmpty(facebookAppSecret))\n 39              {\n 40                  OAuthWebSecurity.RegisterFacebookClient(\n 41                      appId: facebookAppId,"
         lineNumber: 30
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
@@ -172,6 +1464,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.RegisterTwitterClient
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -185,7 +1478,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "29             {\n30                 OAuthWebSecurity.RegisterTwitterClient(\n31                     consumerKey: twitterConsumerKey,\n32                     consumerSecret: twitterConsumerSecret);\n33             }\n34 \n35             var facebookAppId = WebConfigurationManager.AppSettings[\"facebookAppId\"];\n36             var facebookAppSecret = WebConfigurationManager.AppSettings[\"facebookAppSecret\"];\n37             if (!string.IsNullOrEmpty(facebookAppId) && !string.IsNullOrEmpty(facebookAppSecret))\n38             {\n39                 OAuthWebSecurity.RegisterFacebookClient(\n40                     appId: facebookAppId,\n41                     appSecret: facebookAppSecret);\n42             }\n43 \n44             OAuthWebSecurity.RegisterGoogleClient();\n45         }\n46     }\n47 }\n"
+        codeSnip: " 30              {\n 31                  OAuthWebSecurity.RegisterTwitterClient(\n 32                      consumerKey: twitterConsumerKey,\n 33                      consumerSecret: twitterConsumerSecret);\n 34              }\n 35  \n 36              var facebookAppId = WebConfigurationManager.AppSettings[\"facebookAppId\"];\n 37              var facebookAppSecret = WebConfigurationManager.AppSettings[\"facebookAppSecret\"];\n 38              if (!string.IsNullOrEmpty(facebookAppId) && !string.IsNullOrEmpty(facebookAppSecret))\n 39              {\n 40                  OAuthWebSecurity.RegisterFacebookClient(\n 41                      appId: facebookAppId,\n 42                      appSecret: facebookAppSecret);\n 43              }\n 44  \n 45              OAuthWebSecurity.RegisterGoogleClient();\n 46          }\n 47      }\n 48  }"
         lineNumber: 39
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
@@ -194,6 +1487,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.RegisterFacebookClient
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -207,7 +1501,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "34 \n35             var facebookAppId = WebConfigurationManager.AppSettings[\"facebookAppId\"];\n36             var facebookAppSecret = WebConfigurationManager.AppSettings[\"facebookAppSecret\"];\n37             if (!string.IsNullOrEmpty(facebookAppId) && !string.IsNullOrEmpty(facebookAppSecret))\n38             {\n39                 OAuthWebSecurity.RegisterFacebookClient(\n40                     appId: facebookAppId,\n41                     appSecret: facebookAppSecret);\n42             }\n43 \n44             OAuthWebSecurity.RegisterGoogleClient();\n45         }\n46     }\n47 }\n"
+        codeSnip: " 35  \n 36              var facebookAppId = WebConfigurationManager.AppSettings[\"facebookAppId\"];\n 37              var facebookAppSecret = WebConfigurationManager.AppSettings[\"facebookAppSecret\"];\n 38              if (!string.IsNullOrEmpty(facebookAppId) && !string.IsNullOrEmpty(facebookAppSecret))\n 39              {\n 40                  OAuthWebSecurity.RegisterFacebookClient(\n 41                      appId: facebookAppId,\n 42                      appSecret: facebookAppSecret);\n 43              }\n 44  \n 45              OAuthWebSecurity.RegisterGoogleClient();\n 46          }\n 47      }\n 48  }"
         lineNumber: 44
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
@@ -216,6 +1510,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.RegisterGoogleClient
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -229,7 +1524,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "92             return View(model);\n93         }\n94 \n95         //\n96         // POST: /Account/Disassociate\n97 \n98         [HttpPost]\n99         [ValidateAntiForgeryToken]\n100         public ActionResult Disassociate(string provider, string providerUserId)\n101         {\n102             string ownerAccount = OAuthWebSecurity.GetUserName(provider, providerUserId);\n103             ManageMessageId? message = null;\n104 \n105             // Only disassociate the account if the currently logged in user is the owner\n106             if (ownerAccount == User.Identity.Name)\n107             {\n108                 // Use a transaction to prevent the user from deleting their last login credential\n109                 using (var scope = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions { IsolationLevel = IsolationLevel.Serializable }))\n110                 {\n111                     bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n112                     if (hasLocalAccount || OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name).Count > 1)\n"
+        codeSnip: " 93              return View(model);\n 94          }\n 95  \n 96          //\n 97          // POST: /Account/Disassociate\n 98  \n 99          [HttpPost]\n100          [ValidateAntiForgeryToken]\n101          public ActionResult Disassociate(string provider, string providerUserId)\n102          {\n103              string ownerAccount = OAuthWebSecurity.GetUserName(provider, providerUserId);\n104              ManageMessageId? message = null;\n105  \n106              // Only disassociate the account if the currently logged in user is the owner\n107              if (ownerAccount == User.Identity.Name)\n108              {\n109                  // Use a transaction to prevent the user from deleting their last login credential\n110                  using (var scope = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions { IsolationLevel = IsolationLevel.Serializable }))\n111                  {\n112                      bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n113                      if (hasLocalAccount || OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name).Count > 1)"
         lineNumber: 102
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -238,6 +1533,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.GetUserName
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -251,7 +1547,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "101         {\n102             string ownerAccount = OAuthWebSecurity.GetUserName(provider, providerUserId);\n103             ManageMessageId? message = null;\n104 \n105             // Only disassociate the account if the currently logged in user is the owner\n106             if (ownerAccount == User.Identity.Name)\n107             {\n108                 // Use a transaction to prevent the user from deleting their last login credential\n109                 using (var scope = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions { IsolationLevel = IsolationLevel.Serializable }))\n110                 {\n111                     bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n112                     if (hasLocalAccount || OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name).Count > 1)\n113                     {\n114                         OAuthWebSecurity.DeleteAccount(provider, providerUserId);\n115                         scope.Complete();\n116                         message = ManageMessageId.RemoveLoginSuccess;\n117                     }\n118                 }\n119             }\n120 \n121             return RedirectToAction(\"Manage\", new { Message = message });\n"
+        codeSnip: "102          {\n103              string ownerAccount = OAuthWebSecurity.GetUserName(provider, providerUserId);\n104              ManageMessageId? message = null;\n105  \n106              // Only disassociate the account if the currently logged in user is the owner\n107              if (ownerAccount == User.Identity.Name)\n108              {\n109                  // Use a transaction to prevent the user from deleting their last login credential\n110                  using (var scope = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions { IsolationLevel = IsolationLevel.Serializable }))\n111                  {\n112                      bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n113                      if (hasLocalAccount || OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name).Count > 1)\n114                      {\n115                          OAuthWebSecurity.DeleteAccount(provider, providerUserId);\n116                          scope.Complete();\n117                          message = ManageMessageId.RemoveLoginSuccess;\n118                      }\n119                  }\n120              }\n121  \n122              return RedirectToAction(\"Manage\", new { Message = message });"
         lineNumber: 111
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -260,6 +1556,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.HasLocalAccount
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -273,7 +1570,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "102             string ownerAccount = OAuthWebSecurity.GetUserName(provider, providerUserId);\n103             ManageMessageId? message = null;\n104 \n105             // Only disassociate the account if the currently logged in user is the owner\n106             if (ownerAccount == User.Identity.Name)\n107             {\n108                 // Use a transaction to prevent the user from deleting their last login credential\n109                 using (var scope = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions { IsolationLevel = IsolationLevel.Serializable }))\n110                 {\n111                     bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n112                     if (hasLocalAccount || OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name).Count > 1)\n113                     {\n114                         OAuthWebSecurity.DeleteAccount(provider, providerUserId);\n115                         scope.Complete();\n116                         message = ManageMessageId.RemoveLoginSuccess;\n117                     }\n118                 }\n119             }\n120 \n121             return RedirectToAction(\"Manage\", new { Message = message });\n122         }\n"
+        codeSnip: "103              string ownerAccount = OAuthWebSecurity.GetUserName(provider, providerUserId);\n104              ManageMessageId? message = null;\n105  \n106              // Only disassociate the account if the currently logged in user is the owner\n107              if (ownerAccount == User.Identity.Name)\n108              {\n109                  // Use a transaction to prevent the user from deleting their last login credential\n110                  using (var scope = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions { IsolationLevel = IsolationLevel.Serializable }))\n111                  {\n112                      bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n113                      if (hasLocalAccount || OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name).Count > 1)\n114                      {\n115                          OAuthWebSecurity.DeleteAccount(provider, providerUserId);\n116                          scope.Complete();\n117                          message = ManageMessageId.RemoveLoginSuccess;\n118                      }\n119                  }\n120              }\n121  \n122              return RedirectToAction(\"Manage\", new { Message = message });\n123          }"
         lineNumber: 112
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -282,6 +1579,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.GetAccountsFromUserName
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -295,7 +1593,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "104 \n105             // Only disassociate the account if the currently logged in user is the owner\n106             if (ownerAccount == User.Identity.Name)\n107             {\n108                 // Use a transaction to prevent the user from deleting their last login credential\n109                 using (var scope = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions { IsolationLevel = IsolationLevel.Serializable }))\n110                 {\n111                     bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n112                     if (hasLocalAccount || OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name).Count > 1)\n113                     {\n114                         OAuthWebSecurity.DeleteAccount(provider, providerUserId);\n115                         scope.Complete();\n116                         message = ManageMessageId.RemoveLoginSuccess;\n117                     }\n118                 }\n119             }\n120 \n121             return RedirectToAction(\"Manage\", new { Message = message });\n122         }\n123 \n124         //\n"
+        codeSnip: "105  \n106              // Only disassociate the account if the currently logged in user is the owner\n107              if (ownerAccount == User.Identity.Name)\n108              {\n109                  // Use a transaction to prevent the user from deleting their last login credential\n110                  using (var scope = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions { IsolationLevel = IsolationLevel.Serializable }))\n111                  {\n112                      bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n113                      if (hasLocalAccount || OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name).Count > 1)\n114                      {\n115                          OAuthWebSecurity.DeleteAccount(provider, providerUserId);\n116                          scope.Complete();\n117                          message = ManageMessageId.RemoveLoginSuccess;\n118                      }\n119                  }\n120              }\n121  \n122              return RedirectToAction(\"Manage\", new { Message = message });\n123          }\n124  \n125          //"
         lineNumber: 114
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -304,6 +1602,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.DeleteAccount
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -317,7 +1616,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "124         //\n125         // GET: /Account/Manage\n126 \n127         public ActionResult Manage(ManageMessageId? message)\n128         {\n129             ViewBag.StatusMessage =\n130                 message == ManageMessageId.ChangePasswordSuccess ? \"Your password has been changed.\"\n131                 : message == ManageMessageId.SetPasswordSuccess ? \"Your password has been set.\"\n132                 : message == ManageMessageId.RemoveLoginSuccess ? \"The external login was removed.\"\n133                 : \"\";\n134             ViewBag.HasLocalPassword = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n135             ViewBag.ReturnUrl = Url.Action(\"Manage\");\n136             return View();\n137         }\n138 \n139         //\n140         // POST: /Account/Manage\n141 \n142         [HttpPost]\n143         [ValidateAntiForgeryToken]\n144         public ActionResult Manage(LocalPasswordModel model)\n"
+        codeSnip: "125          //\n126          // GET: /Account/Manage\n127  \n128          public ActionResult Manage(ManageMessageId? message)\n129          {\n130              ViewBag.StatusMessage =\n131                  message == ManageMessageId.ChangePasswordSuccess ? \"Your password has been changed.\"\n132                  : message == ManageMessageId.SetPasswordSuccess ? \"Your password has been set.\"\n133                  : message == ManageMessageId.RemoveLoginSuccess ? \"The external login was removed.\"\n134                  : \"\";\n135              ViewBag.HasLocalPassword = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n136              ViewBag.ReturnUrl = Url.Action(\"Manage\");\n137              return View();\n138          }\n139  \n140          //\n141          // POST: /Account/Manage\n142  \n143          [HttpPost]\n144          [ValidateAntiForgeryToken]\n145          public ActionResult Manage(LocalPasswordModel model)"
         lineNumber: 134
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -326,6 +1625,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.HasLocalAccount
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -339,7 +1639,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "136             return View();\n137         }\n138 \n139         //\n140         // POST: /Account/Manage\n141 \n142         [HttpPost]\n143         [ValidateAntiForgeryToken]\n144         public ActionResult Manage(LocalPasswordModel model)\n145         {\n146             bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n147             ViewBag.HasLocalPassword = hasLocalAccount;\n148             ViewBag.ReturnUrl = Url.Action(\"Manage\");\n149             if (hasLocalAccount)\n150             {\n151                 if (ModelState.IsValid)\n152                 {\n153                     // ChangePassword will throw an exception rather than return false in certain failure scenarios.\n154                     bool changePasswordSucceeded;\n155                     try\n156                     {\n"
+        codeSnip: "137              return View();\n138          }\n139  \n140          //\n141          // POST: /Account/Manage\n142  \n143          [HttpPost]\n144          [ValidateAntiForgeryToken]\n145          public ActionResult Manage(LocalPasswordModel model)\n146          {\n147              bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n148              ViewBag.HasLocalPassword = hasLocalAccount;\n149              ViewBag.ReturnUrl = Url.Action(\"Manage\");\n150              if (hasLocalAccount)\n151              {\n152                  if (ModelState.IsValid)\n153                  {\n154                      // ChangePassword will throw an exception rather than return false in certain failure scenarios.\n155                      bool changePasswordSucceeded;\n156                      try\n157                      {"
         lineNumber: 146
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -348,6 +1648,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.HasLocalAccount
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -361,7 +1662,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "209         {\n210             return new ExternalLoginResult(provider, Url.Action(\"ExternalLoginCallback\", new { ReturnUrl = returnUrl }));\n211         }\n212 \n213         //\n214         // GET: /Account/ExternalLoginCallback\n215 \n216         [AllowAnonymous]\n217         public ActionResult ExternalLoginCallback(string returnUrl)\n218         {\n219             AuthenticationResult result = OAuthWebSecurity.VerifyAuthentication(Url.Action(\"ExternalLoginCallback\", new { ReturnUrl = returnUrl }));\n220             if (!result.IsSuccessful)\n221             {\n222                 return RedirectToAction(\"ExternalLoginFailure\");\n223             }\n224 \n225             if (OAuthWebSecurity.Login(result.Provider, result.ProviderUserId, createPersistentCookie: false))\n226             {\n227                 return RedirectToLocal(returnUrl);\n228             }\n229 \n"
+        codeSnip: "210          {\n211              return new ExternalLoginResult(provider, Url.Action(\"ExternalLoginCallback\", new { ReturnUrl = returnUrl }));\n212          }\n213  \n214          //\n215          // GET: /Account/ExternalLoginCallback\n216  \n217          [AllowAnonymous]\n218          public ActionResult ExternalLoginCallback(string returnUrl)\n219          {\n220              AuthenticationResult result = OAuthWebSecurity.VerifyAuthentication(Url.Action(\"ExternalLoginCallback\", new { ReturnUrl = returnUrl }));\n221              if (!result.IsSuccessful)\n222              {\n223                  return RedirectToAction(\"ExternalLoginFailure\");\n224              }\n225  \n226              if (OAuthWebSecurity.Login(result.Provider, result.ProviderUserId, createPersistentCookie: false))\n227              {\n228                  return RedirectToLocal(returnUrl);\n229              }\n230  "
         lineNumber: 219
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -370,6 +1671,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.VerifyAuthentication
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -383,7 +1685,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "215 \n216         [AllowAnonymous]\n217         public ActionResult ExternalLoginCallback(string returnUrl)\n218         {\n219             AuthenticationResult result = OAuthWebSecurity.VerifyAuthentication(Url.Action(\"ExternalLoginCallback\", new { ReturnUrl = returnUrl }));\n220             if (!result.IsSuccessful)\n221             {\n222                 return RedirectToAction(\"ExternalLoginFailure\");\n223             }\n224 \n225             if (OAuthWebSecurity.Login(result.Provider, result.ProviderUserId, createPersistentCookie: false))\n226             {\n227                 return RedirectToLocal(returnUrl);\n228             }\n229 \n230             if (User.Identity.IsAuthenticated)\n231             {\n232                 // If the current user is logged in add the new account\n233                 OAuthWebSecurity.CreateOrUpdateAccount(result.Provider, result.ProviderUserId, User.Identity.Name);\n234                 return RedirectToLocal(returnUrl);\n235             }\n"
+        codeSnip: "216  \n217          [AllowAnonymous]\n218          public ActionResult ExternalLoginCallback(string returnUrl)\n219          {\n220              AuthenticationResult result = OAuthWebSecurity.VerifyAuthentication(Url.Action(\"ExternalLoginCallback\", new { ReturnUrl = returnUrl }));\n221              if (!result.IsSuccessful)\n222              {\n223                  return RedirectToAction(\"ExternalLoginFailure\");\n224              }\n225  \n226              if (OAuthWebSecurity.Login(result.Provider, result.ProviderUserId, createPersistentCookie: false))\n227              {\n228                  return RedirectToLocal(returnUrl);\n229              }\n230  \n231              if (User.Identity.IsAuthenticated)\n232              {\n233                  // If the current user is logged in add the new account\n234                  OAuthWebSecurity.CreateOrUpdateAccount(result.Provider, result.ProviderUserId, User.Identity.Name);\n235                  return RedirectToLocal(returnUrl);\n236              }"
         lineNumber: 225
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -392,6 +1694,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.Login
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -405,7 +1708,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "223             }\n224 \n225             if (OAuthWebSecurity.Login(result.Provider, result.ProviderUserId, createPersistentCookie: false))\n226             {\n227                 return RedirectToLocal(returnUrl);\n228             }\n229 \n230             if (User.Identity.IsAuthenticated)\n231             {\n232                 // If the current user is logged in add the new account\n233                 OAuthWebSecurity.CreateOrUpdateAccount(result.Provider, result.ProviderUserId, User.Identity.Name);\n234                 return RedirectToLocal(returnUrl);\n235             }\n236             else\n237             {\n238                 // User is new, ask for their desired membership name\n239                 string loginData = OAuthWebSecurity.SerializeProviderUserId(result.Provider, result.ProviderUserId);\n240                 ViewBag.ProviderDisplayName = OAuthWebSecurity.GetOAuthClientData(result.Provider).DisplayName;\n241                 ViewBag.ReturnUrl = returnUrl;\n242                 return View(\"ExternalLoginConfirmation\", new RegisterExternalLoginModel { UserName = result.UserName, ExternalLoginData = loginData });\n243             }\n"
+        codeSnip: "224              }\n225  \n226              if (OAuthWebSecurity.Login(result.Provider, result.ProviderUserId, createPersistentCookie: false))\n227              {\n228                  return RedirectToLocal(returnUrl);\n229              }\n230  \n231              if (User.Identity.IsAuthenticated)\n232              {\n233                  // If the current user is logged in add the new account\n234                  OAuthWebSecurity.CreateOrUpdateAccount(result.Provider, result.ProviderUserId, User.Identity.Name);\n235                  return RedirectToLocal(returnUrl);\n236              }\n237              else\n238              {\n239                  // User is new, ask for their desired membership name\n240                  string loginData = OAuthWebSecurity.SerializeProviderUserId(result.Provider, result.ProviderUserId);\n241                  ViewBag.ProviderDisplayName = OAuthWebSecurity.GetOAuthClientData(result.Provider).DisplayName;\n242                  ViewBag.ReturnUrl = returnUrl;\n243                  return View(\"ExternalLoginConfirmation\", new RegisterExternalLoginModel { UserName = result.UserName, ExternalLoginData = loginData });\n244              }"
         lineNumber: 233
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -414,6 +1717,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.CreateOrUpdateAccount
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -427,7 +1731,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "229 \n230             if (User.Identity.IsAuthenticated)\n231             {\n232                 // If the current user is logged in add the new account\n233                 OAuthWebSecurity.CreateOrUpdateAccount(result.Provider, result.ProviderUserId, User.Identity.Name);\n234                 return RedirectToLocal(returnUrl);\n235             }\n236             else\n237             {\n238                 // User is new, ask for their desired membership name\n239                 string loginData = OAuthWebSecurity.SerializeProviderUserId(result.Provider, result.ProviderUserId);\n240                 ViewBag.ProviderDisplayName = OAuthWebSecurity.GetOAuthClientData(result.Provider).DisplayName;\n241                 ViewBag.ReturnUrl = returnUrl;\n242                 return View(\"ExternalLoginConfirmation\", new RegisterExternalLoginModel { UserName = result.UserName, ExternalLoginData = loginData });\n243             }\n244         }\n245 \n246         //\n247         // POST: /Account/ExternalLoginConfirmation\n248 \n249         [HttpPost]\n"
+        codeSnip: "230  \n231              if (User.Identity.IsAuthenticated)\n232              {\n233                  // If the current user is logged in add the new account\n234                  OAuthWebSecurity.CreateOrUpdateAccount(result.Provider, result.ProviderUserId, User.Identity.Name);\n235                  return RedirectToLocal(returnUrl);\n236              }\n237              else\n238              {\n239                  // User is new, ask for their desired membership name\n240                  string loginData = OAuthWebSecurity.SerializeProviderUserId(result.Provider, result.ProviderUserId);\n241                  ViewBag.ProviderDisplayName = OAuthWebSecurity.GetOAuthClientData(result.Provider).DisplayName;\n242                  ViewBag.ReturnUrl = returnUrl;\n243                  return View(\"ExternalLoginConfirmation\", new RegisterExternalLoginModel { UserName = result.UserName, ExternalLoginData = loginData });\n244              }\n245          }\n246  \n247          //\n248          // POST: /Account/ExternalLoginConfirmation\n249  \n250          [HttpPost]"
         lineNumber: 239
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -436,6 +1740,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.SerializeProviderUserId
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -449,7 +1754,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "230             if (User.Identity.IsAuthenticated)\n231             {\n232                 // If the current user is logged in add the new account\n233                 OAuthWebSecurity.CreateOrUpdateAccount(result.Provider, result.ProviderUserId, User.Identity.Name);\n234                 return RedirectToLocal(returnUrl);\n235             }\n236             else\n237             {\n238                 // User is new, ask for their desired membership name\n239                 string loginData = OAuthWebSecurity.SerializeProviderUserId(result.Provider, result.ProviderUserId);\n240                 ViewBag.ProviderDisplayName = OAuthWebSecurity.GetOAuthClientData(result.Provider).DisplayName;\n241                 ViewBag.ReturnUrl = returnUrl;\n242                 return View(\"ExternalLoginConfirmation\", new RegisterExternalLoginModel { UserName = result.UserName, ExternalLoginData = loginData });\n243             }\n244         }\n245 \n246         //\n247         // POST: /Account/ExternalLoginConfirmation\n248 \n249         [HttpPost]\n250         [AllowAnonymous]\n"
+        codeSnip: "231              if (User.Identity.IsAuthenticated)\n232              {\n233                  // If the current user is logged in add the new account\n234                  OAuthWebSecurity.CreateOrUpdateAccount(result.Provider, result.ProviderUserId, User.Identity.Name);\n235                  return RedirectToLocal(returnUrl);\n236              }\n237              else\n238              {\n239                  // User is new, ask for their desired membership name\n240                  string loginData = OAuthWebSecurity.SerializeProviderUserId(result.Provider, result.ProviderUserId);\n241                  ViewBag.ProviderDisplayName = OAuthWebSecurity.GetOAuthClientData(result.Provider).DisplayName;\n242                  ViewBag.ReturnUrl = returnUrl;\n243                  return View(\"ExternalLoginConfirmation\", new RegisterExternalLoginModel { UserName = result.UserName, ExternalLoginData = loginData });\n244              }\n245          }\n246  \n247          //\n248          // POST: /Account/ExternalLoginConfirmation\n249  \n250          [HttpPost]\n251          [AllowAnonymous]"
         lineNumber: 240
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -458,6 +1763,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.GetOAuthClientData
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -471,7 +1777,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "247         // POST: /Account/ExternalLoginConfirmation\n248 \n249         [HttpPost]\n250         [AllowAnonymous]\n251         [ValidateAntiForgeryToken]\n252         public ActionResult ExternalLoginConfirmation(RegisterExternalLoginModel model, string returnUrl)\n253         {\n254             string provider = null;\n255             string providerUserId = null;\n256 \n257             if (User.Identity.IsAuthenticated || !OAuthWebSecurity.TryDeserializeProviderUserId(model.ExternalLoginData, out provider, out providerUserId))\n258             {\n259                 return RedirectToAction(\"Manage\");\n260             }\n261 \n262             if (ModelState.IsValid)\n263             {\n264                 // Insert a new user into the database\n265                 using (UsersContext db = new UsersContext())\n266                 {\n267                     UserProfile user = db.UserProfiles.FirstOrDefault(u => u.UserName.ToLower() == model.UserName.ToLower());\n"
+        codeSnip: "248          // POST: /Account/ExternalLoginConfirmation\n249  \n250          [HttpPost]\n251          [AllowAnonymous]\n252          [ValidateAntiForgeryToken]\n253          public ActionResult ExternalLoginConfirmation(RegisterExternalLoginModel model, string returnUrl)\n254          {\n255              string provider = null;\n256              string providerUserId = null;\n257  \n258              if (User.Identity.IsAuthenticated || !OAuthWebSecurity.TryDeserializeProviderUserId(model.ExternalLoginData, out provider, out providerUserId))\n259              {\n260                  return RedirectToAction(\"Manage\");\n261              }\n262  \n263              if (ModelState.IsValid)\n264              {\n265                  // Insert a new user into the database\n266                  using (UsersContext db = new UsersContext())\n267                  {\n268                      UserProfile user = db.UserProfiles.FirstOrDefault(u => u.UserName.ToLower() == model.UserName.ToLower());"
         lineNumber: 257
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -480,6 +1786,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.TryDeserializeProviderUserId
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -493,7 +1800,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "265                 using (UsersContext db = new UsersContext())\n266                 {\n267                     UserProfile user = db.UserProfiles.FirstOrDefault(u => u.UserName.ToLower() == model.UserName.ToLower());\n268                     // Check if user already exists\n269                     if (user == null)\n270                     {\n271                         // Insert name into the profile table\n272                         db.UserProfiles.Add(new UserProfile { UserName = model.UserName });\n273                         db.SaveChanges();\n274 \n275                         OAuthWebSecurity.CreateOrUpdateAccount(provider, providerUserId, model.UserName);\n276                         OAuthWebSecurity.Login(provider, providerUserId, createPersistentCookie: false);\n277 \n278                         return RedirectToLocal(returnUrl);\n279                     }\n280                     else\n281                     {\n282                         ModelState.AddModelError(\"UserName\", \"User name already exists. Please enter a different user name.\");\n283                     }\n284                 }\n285             }\n"
+        codeSnip: "266                  using (UsersContext db = new UsersContext())\n267                  {\n268                      UserProfile user = db.UserProfiles.FirstOrDefault(u => u.UserName.ToLower() == model.UserName.ToLower());\n269                      // Check if user already exists\n270                      if (user == null)\n271                      {\n272                          // Insert name into the profile table\n273                          db.UserProfiles.Add(new UserProfile { UserName = model.UserName });\n274                          db.SaveChanges();\n275  \n276                          OAuthWebSecurity.CreateOrUpdateAccount(provider, providerUserId, model.UserName);\n277                          OAuthWebSecurity.Login(provider, providerUserId, createPersistentCookie: false);\n278  \n279                          return RedirectToLocal(returnUrl);\n280                      }\n281                      else\n282                      {\n283                          ModelState.AddModelError(\"UserName\", \"User name already exists. Please enter a different user name.\");\n284                      }\n285                  }\n286              }"
         lineNumber: 275
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -502,6 +1809,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.CreateOrUpdateAccount
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -515,7 +1823,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "266                 {\n267                     UserProfile user = db.UserProfiles.FirstOrDefault(u => u.UserName.ToLower() == model.UserName.ToLower());\n268                     // Check if user already exists\n269                     if (user == null)\n270                     {\n271                         // Insert name into the profile table\n272                         db.UserProfiles.Add(new UserProfile { UserName = model.UserName });\n273                         db.SaveChanges();\n274 \n275                         OAuthWebSecurity.CreateOrUpdateAccount(provider, providerUserId, model.UserName);\n276                         OAuthWebSecurity.Login(provider, providerUserId, createPersistentCookie: false);\n277 \n278                         return RedirectToLocal(returnUrl);\n279                     }\n280                     else\n281                     {\n282                         ModelState.AddModelError(\"UserName\", \"User name already exists. Please enter a different user name.\");\n283                     }\n284                 }\n285             }\n286 \n"
+        codeSnip: "267                  {\n268                      UserProfile user = db.UserProfiles.FirstOrDefault(u => u.UserName.ToLower() == model.UserName.ToLower());\n269                      // Check if user already exists\n270                      if (user == null)\n271                      {\n272                          // Insert name into the profile table\n273                          db.UserProfiles.Add(new UserProfile { UserName = model.UserName });\n274                          db.SaveChanges();\n275  \n276                          OAuthWebSecurity.CreateOrUpdateAccount(provider, providerUserId, model.UserName);\n277                          OAuthWebSecurity.Login(provider, providerUserId, createPersistentCookie: false);\n278  \n279                          return RedirectToLocal(returnUrl);\n280                      }\n281                      else\n282                      {\n283                          ModelState.AddModelError(\"UserName\", \"User name already exists. Please enter a different user name.\");\n284                      }\n285                  }\n286              }\n287  "
         lineNumber: 276
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -524,6 +1832,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.Login
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -537,7 +1846,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "277 \n278                         return RedirectToLocal(returnUrl);\n279                     }\n280                     else\n281                     {\n282                         ModelState.AddModelError(\"UserName\", \"User name already exists. Please enter a different user name.\");\n283                     }\n284                 }\n285             }\n286 \n287             ViewBag.ProviderDisplayName = OAuthWebSecurity.GetOAuthClientData(provider).DisplayName;\n288             ViewBag.ReturnUrl = returnUrl;\n289             return View(model);\n290         }\n291 \n292         //\n293         // GET: /Account/ExternalLoginFailure\n294 \n295         [AllowAnonymous]\n296         public ActionResult ExternalLoginFailure()\n297         {\n"
+        codeSnip: "278  \n279                          return RedirectToLocal(returnUrl);\n280                      }\n281                      else\n282                      {\n283                          ModelState.AddModelError(\"UserName\", \"User name already exists. Please enter a different user name.\");\n284                      }\n285                  }\n286              }\n287  \n288              ViewBag.ProviderDisplayName = OAuthWebSecurity.GetOAuthClientData(provider).DisplayName;\n289              ViewBag.ReturnUrl = returnUrl;\n290              return View(model);\n291          }\n292  \n293          //\n294          // GET: /Account/ExternalLoginFailure\n295  \n296          [AllowAnonymous]\n297          public ActionResult ExternalLoginFailure()\n298          {"
         lineNumber: 287
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -546,6 +1855,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.GetOAuthClientData
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -559,7 +1869,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "296         public ActionResult ExternalLoginFailure()\n297         {\n298             return View();\n299         }\n300 \n301         [AllowAnonymous]\n302         [ChildActionOnly]\n303         public ActionResult ExternalLoginsList(string returnUrl)\n304         {\n305             ViewBag.ReturnUrl = returnUrl;\n306             return PartialView(\"_ExternalLoginsListPartial\", OAuthWebSecurity.RegisteredClientData);\n307         }\n308 \n309         [ChildActionOnly]\n310         public ActionResult RemoveExternalLogins()\n311         {\n312             ICollection<OAuthAccount> accounts = OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name);\n313             List<ExternalLogin> externalLogins = new List<ExternalLogin>();\n314             foreach (OAuthAccount account in accounts)\n315             {\n316                 AuthenticationClientData clientData = OAuthWebSecurity.GetOAuthClientData(account.Provider);\n"
+        codeSnip: "297          public ActionResult ExternalLoginFailure()\n298          {\n299              return View();\n300          }\n301  \n302          [AllowAnonymous]\n303          [ChildActionOnly]\n304          public ActionResult ExternalLoginsList(string returnUrl)\n305          {\n306              ViewBag.ReturnUrl = returnUrl;\n307              return PartialView(\"_ExternalLoginsListPartial\", OAuthWebSecurity.RegisteredClientData);\n308          }\n309  \n310          [ChildActionOnly]\n311          public ActionResult RemoveExternalLogins()\n312          {\n313              ICollection<OAuthAccount> accounts = OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name);\n314              List<ExternalLogin> externalLogins = new List<ExternalLogin>();\n315              foreach (OAuthAccount account in accounts)\n316              {\n317                  AuthenticationClientData clientData = OAuthWebSecurity.GetOAuthClientData(account.Provider);"
         lineNumber: 306
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -568,6 +1878,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.RegisteredClientData
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -581,7 +1892,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "302         [ChildActionOnly]\n303         public ActionResult ExternalLoginsList(string returnUrl)\n304         {\n305             ViewBag.ReturnUrl = returnUrl;\n306             return PartialView(\"_ExternalLoginsListPartial\", OAuthWebSecurity.RegisteredClientData);\n307         }\n308 \n309         [ChildActionOnly]\n310         public ActionResult RemoveExternalLogins()\n311         {\n312             ICollection<OAuthAccount> accounts = OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name);\n313             List<ExternalLogin> externalLogins = new List<ExternalLogin>();\n314             foreach (OAuthAccount account in accounts)\n315             {\n316                 AuthenticationClientData clientData = OAuthWebSecurity.GetOAuthClientData(account.Provider);\n317 \n318                 externalLogins.Add(new ExternalLogin\n319                 {\n320                     Provider = account.Provider,\n321                     ProviderDisplayName = clientData.DisplayName,\n322                     ProviderUserId = account.ProviderUserId,\n"
+        codeSnip: "303          [ChildActionOnly]\n304          public ActionResult ExternalLoginsList(string returnUrl)\n305          {\n306              ViewBag.ReturnUrl = returnUrl;\n307              return PartialView(\"_ExternalLoginsListPartial\", OAuthWebSecurity.RegisteredClientData);\n308          }\n309  \n310          [ChildActionOnly]\n311          public ActionResult RemoveExternalLogins()\n312          {\n313              ICollection<OAuthAccount> accounts = OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name);\n314              List<ExternalLogin> externalLogins = new List<ExternalLogin>();\n315              foreach (OAuthAccount account in accounts)\n316              {\n317                  AuthenticationClientData clientData = OAuthWebSecurity.GetOAuthClientData(account.Provider);\n318  \n319                  externalLogins.Add(new ExternalLogin\n320                  {\n321                      Provider = account.Provider,\n322                      ProviderDisplayName = clientData.DisplayName,\n323                      ProviderUserId = account.ProviderUserId,"
         lineNumber: 312
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -590,6 +1901,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.GetAccountsFromUserName
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -603,7 +1915,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "306             return PartialView(\"_ExternalLoginsListPartial\", OAuthWebSecurity.RegisteredClientData);\n307         }\n308 \n309         [ChildActionOnly]\n310         public ActionResult RemoveExternalLogins()\n311         {\n312             ICollection<OAuthAccount> accounts = OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name);\n313             List<ExternalLogin> externalLogins = new List<ExternalLogin>();\n314             foreach (OAuthAccount account in accounts)\n315             {\n316                 AuthenticationClientData clientData = OAuthWebSecurity.GetOAuthClientData(account.Provider);\n317 \n318                 externalLogins.Add(new ExternalLogin\n319                 {\n320                     Provider = account.Provider,\n321                     ProviderDisplayName = clientData.DisplayName,\n322                     ProviderUserId = account.ProviderUserId,\n323                 });\n324             }\n325 \n326             ViewBag.ShowRemoveButton = externalLogins.Count > 1 || OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n"
+        codeSnip: "307              return PartialView(\"_ExternalLoginsListPartial\", OAuthWebSecurity.RegisteredClientData);\n308          }\n309  \n310          [ChildActionOnly]\n311          public ActionResult RemoveExternalLogins()\n312          {\n313              ICollection<OAuthAccount> accounts = OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name);\n314              List<ExternalLogin> externalLogins = new List<ExternalLogin>();\n315              foreach (OAuthAccount account in accounts)\n316              {\n317                  AuthenticationClientData clientData = OAuthWebSecurity.GetOAuthClientData(account.Provider);\n318  \n319                  externalLogins.Add(new ExternalLogin\n320                  {\n321                      Provider = account.Provider,\n322                      ProviderDisplayName = clientData.DisplayName,\n323                      ProviderUserId = account.ProviderUserId,\n324                  });\n325              }\n326  \n327              ViewBag.ShowRemoveButton = externalLogins.Count > 1 || OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));"
         lineNumber: 316
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -612,6 +1924,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.GetOAuthClientData
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -625,7 +1938,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "316                 AuthenticationClientData clientData = OAuthWebSecurity.GetOAuthClientData(account.Provider);\n317 \n318                 externalLogins.Add(new ExternalLogin\n319                 {\n320                     Provider = account.Provider,\n321                     ProviderDisplayName = clientData.DisplayName,\n322                     ProviderUserId = account.ProviderUserId,\n323                 });\n324             }\n325 \n326             ViewBag.ShowRemoveButton = externalLogins.Count > 1 || OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n327             return PartialView(\"_RemoveExternalLoginsPartial\", externalLogins);\n328         }\n329 \n330         #region Helpers\n331         private ActionResult RedirectToLocal(string returnUrl)\n332         {\n333             if (Url.IsLocalUrl(returnUrl))\n334             {\n335                 return Redirect(returnUrl);\n336             }\n"
+        codeSnip: "317                  AuthenticationClientData clientData = OAuthWebSecurity.GetOAuthClientData(account.Provider);\n318  \n319                  externalLogins.Add(new ExternalLogin\n320                  {\n321                      Provider = account.Provider,\n322                      ProviderDisplayName = clientData.DisplayName,\n323                      ProviderUserId = account.ProviderUserId,\n324                  });\n325              }\n326  \n327              ViewBag.ShowRemoveButton = externalLogins.Count > 1 || OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n328              return PartialView(\"_RemoveExternalLoginsPartial\", externalLogins);\n329          }\n330  \n331          #region Helpers\n332          private ActionResult RedirectToLocal(string returnUrl)\n333          {\n334              if (Url.IsLocalUrl(returnUrl))\n335              {\n336                  return Redirect(returnUrl);\n337              }"
         lineNumber: 326
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -634,6 +1947,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.HasLocalAccount
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           Microsoft.Web.WebPages.OAuth.OAuthWebSecurity is not available in .NET Core.
@@ -647,7 +1961,7 @@
           - Configure external providers in Startup.ConfigureServices using AddAuthentication()
           - Add required NuGet packages (e.g., Microsoft.AspNetCore.Authentication.Google)
           - Update authentication flow to use ASP.NET Core Identity external login pattern
-        codeSnip: "353             {\n354                 Provider = provider;\n355                 ReturnUrl = returnUrl;\n356             }\n357 \n358             public string Provider { get; private set; }\n359             public string ReturnUrl { get; private set; }\n360 \n361             public override void ExecuteResult(ControllerContext context)\n362             {\n363                 OAuthWebSecurity.RequestAuthentication(Provider, ReturnUrl);\n364             }\n365         }\n366 \n367         private static string ErrorCodeToString(MembershipCreateStatus createStatus)\n368         {\n369             // See http://go.microsoft.com/fwlink/?LinkID=177550 for\n370             // a full list of status codes.\n371             switch (createStatus)\n372             {\n373                 case MembershipCreateStatus.DuplicateUserName:\n"
+        codeSnip: "354              {\n355                  Provider = provider;\n356                  ReturnUrl = returnUrl;\n357              }\n358  \n359              public string Provider { get; private set; }\n360              public string ReturnUrl { get; private set; }\n361  \n362              public override void ExecuteResult(ControllerContext context)\n363              {\n364                  OAuthWebSecurity.RequestAuthentication(Provider, ReturnUrl);\n365              }\n366          }\n367  \n368          private static string ErrorCodeToString(MembershipCreateStatus createStatus)\n369          {\n370              // See http://go.microsoft.com/fwlink/?LinkID=177550 for\n371              // a full list of status codes.\n372              switch (createStatus)\n373              {\n374                  case MembershipCreateStatus.DuplicateUserName:"
         lineNumber: 363
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -656,6 +1970,7 @@
           fqdn_namespace: Microsoft.Web.WebPages.OAuth
           symbol: OAuthWebSecurity.RequestAuthentication
           syntax_type: method_reference
+        isDependencyIncident: false
       links:
       - url: https://learn.microsoft.com/en-us/aspnet/core/security/authentication/social/
         title: External OAuth authentication providers
@@ -664,6 +1979,605 @@
       - url: https://learn.microsoft.com/en-us/aspnet/core/security/authentication/social/google-logins
         title: Google external login setup
       effort: 8
+    dotnet-core-optimization-01:
+      description: System.Web.Optimization bundling is not available in .NET Core
+      category: mandatory
+      labels:
+      - konveyor.io/source=dotnet
+      - konveyor.io/target=dotnet-core
+      incidents:
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+        message: |
+          System.Web.Optimization is not available in .NET Core.
+          Bundling and minification are handled differently in ASP.NET Core.
+
+          Migration actions:
+          - Remove BundleConfig.cs
+          - Use BuildBundlerMinifier NuGet package, or
+          - Use Webpack, Gulp, or other build-time bundlers, or
+          - Use ASP.NET Core bundling libraries like WebOptimizer
+          - Update views to reference individual files or new bundle definitions
+        codeSnip: "  1  using System.Web;\n  2  using System.Web.Optimization;\n  3  \n  4  namespace NerdDinner\n  5  {\n  6      public class BundleConfig\n  7      {\n  8          // For more information on Bundling, visit http://go.microsoft.com/fwlink/?LinkId=254725\n  9          public static void RegisterBundles(BundleCollection bundles)\n 10          {\n 11              bundles.Add(new ScriptBundle(\"~/bundles/jquery\").Include(\n 12                          \"~/Scripts/jquery-{version}.js\"));"
+        lineNumber: 1
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+          fqdn_namespace: System.Web.Optimization
+          symbol: System.Web.Optimization
+          syntax_type: import
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+        message: |
+          System.Web.Optimization is not available in .NET Core.
+          Bundling and minification are handled differently in ASP.NET Core.
+
+          Migration actions:
+          - Remove BundleConfig.cs
+          - Use BuildBundlerMinifier NuGet package, or
+          - Use Webpack, Gulp, or other build-time bundlers, or
+          - Use ASP.NET Core bundling libraries like WebOptimizer
+          - Update views to reference individual files or new bundle definitions
+        codeSnip: "  1  using System.Web;\n  2  using System.Web.Optimization;\n  3  \n  4  namespace NerdDinner\n  5  {\n  6      public class BundleConfig\n  7      {\n  8          // For more information on Bundling, visit http://go.microsoft.com/fwlink/?LinkId=254725\n  9          public static void RegisterBundles(BundleCollection bundles)\n 10          {\n 11              bundles.Add(new ScriptBundle(\"~/bundles/jquery\").Include(\n 12                          \"~/Scripts/jquery-{version}.js\"));\n 13  \n 14              bundles.Add(new ScriptBundle(\"~/bundles/jqueryui\").Include(\n 15                          \"~/Scripts/jquery-ui-{version}.js\"));\n 16  \n 17              bundles.Add(new ScriptBundle(\"~/bundles/jqueryval\").Include(\n 18                          \"~/Scripts/jquery.unobtrusive*\",\n 19                          \"~/Scripts/jquery.validate*\"));"
+        lineNumber: 8
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+          fqdn_class: BundleCollection
+          fqdn_namespace: System.Web.Optimization
+          symbol: BundleCollection
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+        message: |
+          System.Web.Optimization is not available in .NET Core.
+          Bundling and minification are handled differently in ASP.NET Core.
+
+          Migration actions:
+          - Remove BundleConfig.cs
+          - Use BuildBundlerMinifier NuGet package, or
+          - Use Webpack, Gulp, or other build-time bundlers, or
+          - Use ASP.NET Core bundling libraries like WebOptimizer
+          - Update views to reference individual files or new bundle definitions
+        codeSnip: "  1  using System.Web;\n  2  using System.Web.Optimization;\n  3  \n  4  namespace NerdDinner\n  5  {\n  6      public class BundleConfig\n  7      {\n  8          // For more information on Bundling, visit http://go.microsoft.com/fwlink/?LinkId=254725\n  9          public static void RegisterBundles(BundleCollection bundles)\n 10          {\n 11              bundles.Add(new ScriptBundle(\"~/bundles/jquery\").Include(\n 12                          \"~/Scripts/jquery-{version}.js\"));\n 13  \n 14              bundles.Add(new ScriptBundle(\"~/bundles/jqueryui\").Include(\n 15                          \"~/Scripts/jquery-ui-{version}.js\"));\n 16  \n 17              bundles.Add(new ScriptBundle(\"~/bundles/jqueryval\").Include(\n 18                          \"~/Scripts/jquery.unobtrusive*\",\n 19                          \"~/Scripts/jquery.validate*\"));\n 20  \n 21              bundles.Add(new ScriptBundle(\"~/bundles/jquerymobile\").Include("
+        lineNumber: 10
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+          fqdn_class: BundleCollection
+          fqdn_method: Add
+          fqdn_namespace: System.Web.Optimization
+          symbol: bundles.Add
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+        message: |
+          System.Web.Optimization is not available in .NET Core.
+          Bundling and minification are handled differently in ASP.NET Core.
+
+          Migration actions:
+          - Remove BundleConfig.cs
+          - Use BuildBundlerMinifier NuGet package, or
+          - Use Webpack, Gulp, or other build-time bundlers, or
+          - Use ASP.NET Core bundling libraries like WebOptimizer
+          - Update views to reference individual files or new bundle definitions
+        codeSnip: "  4  namespace NerdDinner\n  5  {\n  6      public class BundleConfig\n  7      {\n  8          // For more information on Bundling, visit http://go.microsoft.com/fwlink/?LinkId=254725\n  9          public static void RegisterBundles(BundleCollection bundles)\n 10          {\n 11              bundles.Add(new ScriptBundle(\"~/bundles/jquery\").Include(\n 12                          \"~/Scripts/jquery-{version}.js\"));\n 13  \n 14              bundles.Add(new ScriptBundle(\"~/bundles/jqueryui\").Include(\n 15                          \"~/Scripts/jquery-ui-{version}.js\"));\n 16  \n 17              bundles.Add(new ScriptBundle(\"~/bundles/jqueryval\").Include(\n 18                          \"~/Scripts/jquery.unobtrusive*\",\n 19                          \"~/Scripts/jquery.validate*\"));\n 20  \n 21              bundles.Add(new ScriptBundle(\"~/bundles/jquerymobile\").Include(\n 22                          \"~/Scripts/jquery.mobile-{version}.js\"));\n 23  \n 24              // Use the development version of Modernizr to develop with and learn from. Then, when you're"
+        lineNumber: 13
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+          fqdn_class: BundleCollection
+          fqdn_method: Add
+          fqdn_namespace: System.Web.Optimization
+          symbol: bundles.Add
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+        message: |
+          System.Web.Optimization is not available in .NET Core.
+          Bundling and minification are handled differently in ASP.NET Core.
+
+          Migration actions:
+          - Remove BundleConfig.cs
+          - Use BuildBundlerMinifier NuGet package, or
+          - Use Webpack, Gulp, or other build-time bundlers, or
+          - Use ASP.NET Core bundling libraries like WebOptimizer
+          - Update views to reference individual files or new bundle definitions
+        codeSnip: "  7      {\n  8          // For more information on Bundling, visit http://go.microsoft.com/fwlink/?LinkId=254725\n  9          public static void RegisterBundles(BundleCollection bundles)\n 10          {\n 11              bundles.Add(new ScriptBundle(\"~/bundles/jquery\").Include(\n 12                          \"~/Scripts/jquery-{version}.js\"));\n 13  \n 14              bundles.Add(new ScriptBundle(\"~/bundles/jqueryui\").Include(\n 15                          \"~/Scripts/jquery-ui-{version}.js\"));\n 16  \n 17              bundles.Add(new ScriptBundle(\"~/bundles/jqueryval\").Include(\n 18                          \"~/Scripts/jquery.unobtrusive*\",\n 19                          \"~/Scripts/jquery.validate*\"));\n 20  \n 21              bundles.Add(new ScriptBundle(\"~/bundles/jquerymobile\").Include(\n 22                          \"~/Scripts/jquery.mobile-{version}.js\"));\n 23  \n 24              // Use the development version of Modernizr to develop with and learn from. Then, when you're\n 25              // ready for production, use the build tool at http://modernizr.com to pick only the tests you need.\n 26              bundles.Add(new ScriptBundle(\"~/bundles/modernizr\").Include(\n 27                          \"~/Scripts/modernizr-*\"));"
+        lineNumber: 16
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+          fqdn_class: BundleCollection
+          fqdn_method: Add
+          fqdn_namespace: System.Web.Optimization
+          symbol: bundles.Add
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+        message: |
+          System.Web.Optimization is not available in .NET Core.
+          Bundling and minification are handled differently in ASP.NET Core.
+
+          Migration actions:
+          - Remove BundleConfig.cs
+          - Use BuildBundlerMinifier NuGet package, or
+          - Use Webpack, Gulp, or other build-time bundlers, or
+          - Use ASP.NET Core bundling libraries like WebOptimizer
+          - Update views to reference individual files or new bundle definitions
+        codeSnip: " 11              bundles.Add(new ScriptBundle(\"~/bundles/jquery\").Include(\n 12                          \"~/Scripts/jquery-{version}.js\"));\n 13  \n 14              bundles.Add(new ScriptBundle(\"~/bundles/jqueryui\").Include(\n 15                          \"~/Scripts/jquery-ui-{version}.js\"));\n 16  \n 17              bundles.Add(new ScriptBundle(\"~/bundles/jqueryval\").Include(\n 18                          \"~/Scripts/jquery.unobtrusive*\",\n 19                          \"~/Scripts/jquery.validate*\"));\n 20  \n 21              bundles.Add(new ScriptBundle(\"~/bundles/jquerymobile\").Include(\n 22                          \"~/Scripts/jquery.mobile-{version}.js\"));\n 23  \n 24              // Use the development version of Modernizr to develop with and learn from. Then, when you're\n 25              // ready for production, use the build tool at http://modernizr.com to pick only the tests you need.\n 26              bundles.Add(new ScriptBundle(\"~/bundles/modernizr\").Include(\n 27                          \"~/Scripts/modernizr-*\"));\n 28  \n 29              bundles.Add(new ScriptBundle(\"~/bundles/knockout\").Include(\n 30                          \"~/Scripts/knockout-*\"));\n 31  "
+        lineNumber: 20
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+          fqdn_class: BundleCollection
+          fqdn_method: Add
+          fqdn_namespace: System.Web.Optimization
+          symbol: bundles.Add
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+        message: |
+          System.Web.Optimization is not available in .NET Core.
+          Bundling and minification are handled differently in ASP.NET Core.
+
+          Migration actions:
+          - Remove BundleConfig.cs
+          - Use BuildBundlerMinifier NuGet package, or
+          - Use Webpack, Gulp, or other build-time bundlers, or
+          - Use ASP.NET Core bundling libraries like WebOptimizer
+          - Update views to reference individual files or new bundle definitions
+        codeSnip: " 16  \n 17              bundles.Add(new ScriptBundle(\"~/bundles/jqueryval\").Include(\n 18                          \"~/Scripts/jquery.unobtrusive*\",\n 19                          \"~/Scripts/jquery.validate*\"));\n 20  \n 21              bundles.Add(new ScriptBundle(\"~/bundles/jquerymobile\").Include(\n 22                          \"~/Scripts/jquery.mobile-{version}.js\"));\n 23  \n 24              // Use the development version of Modernizr to develop with and learn from. Then, when you're\n 25              // ready for production, use the build tool at http://modernizr.com to pick only the tests you need.\n 26              bundles.Add(new ScriptBundle(\"~/bundles/modernizr\").Include(\n 27                          \"~/Scripts/modernizr-*\"));\n 28  \n 29              bundles.Add(new ScriptBundle(\"~/bundles/knockout\").Include(\n 30                          \"~/Scripts/knockout-*\"));\n 31  \n 32              bundles.Add(new ScriptBundle(\"~/bundles/yepnope\").Include(\n 33                          \"~/Scripts/yepnope.{version}.js\"));\n 34  \n 35              bundles.Add(new StyleBundle(\"~/Content/css\").Include(\"~/Content/site.css\"));\n 36  "
+        lineNumber: 25
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+          fqdn_class: BundleCollection
+          fqdn_method: Add
+          fqdn_namespace: System.Web.Optimization
+          symbol: bundles.Add
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+        message: |
+          System.Web.Optimization is not available in .NET Core.
+          Bundling and minification are handled differently in ASP.NET Core.
+
+          Migration actions:
+          - Remove BundleConfig.cs
+          - Use BuildBundlerMinifier NuGet package, or
+          - Use Webpack, Gulp, or other build-time bundlers, or
+          - Use ASP.NET Core bundling libraries like WebOptimizer
+          - Update views to reference individual files or new bundle definitions
+        codeSnip: " 19                          \"~/Scripts/jquery.validate*\"));\n 20  \n 21              bundles.Add(new ScriptBundle(\"~/bundles/jquerymobile\").Include(\n 22                          \"~/Scripts/jquery.mobile-{version}.js\"));\n 23  \n 24              // Use the development version of Modernizr to develop with and learn from. Then, when you're\n 25              // ready for production, use the build tool at http://modernizr.com to pick only the tests you need.\n 26              bundles.Add(new ScriptBundle(\"~/bundles/modernizr\").Include(\n 27                          \"~/Scripts/modernizr-*\"));\n 28  \n 29              bundles.Add(new ScriptBundle(\"~/bundles/knockout\").Include(\n 30                          \"~/Scripts/knockout-*\"));\n 31  \n 32              bundles.Add(new ScriptBundle(\"~/bundles/yepnope\").Include(\n 33                          \"~/Scripts/yepnope.{version}.js\"));\n 34  \n 35              bundles.Add(new StyleBundle(\"~/Content/css\").Include(\"~/Content/site.css\"));\n 36  \n 37              bundles.Add(new StyleBundle(\"~/Content/themes/base/css\").Include(\n 38                          \"~/Content/themes/base/jquery.ui.core.css\",\n 39                          \"~/Content/themes/base/jquery.ui.resizable.css\","
+        lineNumber: 28
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+          fqdn_class: BundleCollection
+          fqdn_method: Add
+          fqdn_namespace: System.Web.Optimization
+          symbol: bundles.Add
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+        message: |
+          System.Web.Optimization is not available in .NET Core.
+          Bundling and minification are handled differently in ASP.NET Core.
+
+          Migration actions:
+          - Remove BundleConfig.cs
+          - Use BuildBundlerMinifier NuGet package, or
+          - Use Webpack, Gulp, or other build-time bundlers, or
+          - Use ASP.NET Core bundling libraries like WebOptimizer
+          - Update views to reference individual files or new bundle definitions
+        lineNumber: 31
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+          fqdn_class: BundleCollection
+          fqdn_method: Add
+          fqdn_namespace: System.Web.Optimization
+          symbol: bundles.Add
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+        message: |
+          System.Web.Optimization is not available in .NET Core.
+          Bundling and minification are handled differently in ASP.NET Core.
+
+          Migration actions:
+          - Remove BundleConfig.cs
+          - Use BuildBundlerMinifier NuGet package, or
+          - Use Webpack, Gulp, or other build-time bundlers, or
+          - Use ASP.NET Core bundling libraries like WebOptimizer
+          - Update views to reference individual files or new bundle definitions
+        lineNumber: 34
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+          fqdn_class: BundleCollection
+          fqdn_method: Add
+          fqdn_namespace: System.Web.Optimization
+          symbol: bundles.Add
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+        message: |
+          System.Web.Optimization is not available in .NET Core.
+          Bundling and minification are handled differently in ASP.NET Core.
+
+          Migration actions:
+          - Remove BundleConfig.cs
+          - Use BuildBundlerMinifier NuGet package, or
+          - Use Webpack, Gulp, or other build-time bundlers, or
+          - Use ASP.NET Core bundling libraries like WebOptimizer
+          - Update views to reference individual files or new bundle definitions
+        lineNumber: 36
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+          fqdn_class: BundleCollection
+          fqdn_method: Add
+          fqdn_namespace: System.Web.Optimization
+          symbol: bundles.Add
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+        message: |
+          System.Web.Optimization is not available in .NET Core.
+          Bundling and minification are handled differently in ASP.NET Core.
+
+          Migration actions:
+          - Remove BundleConfig.cs
+          - Use BuildBundlerMinifier NuGet package, or
+          - Use Webpack, Gulp, or other build-time bundlers, or
+          - Use ASP.NET Core bundling libraries like WebOptimizer
+          - Update views to reference individual files or new bundle definitions
+        lineNumber: 50
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/BundleConfig.cs
+          fqdn_class: BundleCollection
+          fqdn_method: Add
+          fqdn_namespace: System.Web.Optimization
+          symbol: bundles.Add
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
+        message: |
+          System.Web.Optimization is not available in .NET Core.
+          Bundling and minification are handled differently in ASP.NET Core.
+
+          Migration actions:
+          - Remove BundleConfig.cs
+          - Use BuildBundlerMinifier NuGet package, or
+          - Use Webpack, Gulp, or other build-time bundlers, or
+          - Use ASP.NET Core bundling libraries like WebOptimizer
+          - Update views to reference individual files or new bundle definitions
+        codeSnip: "  1  using System;\n  2  using System.Collections.Generic;\n  3  using System.Linq;\n  4  using System.Reflection;\n  5  using System.Web;\n  6  using System.Web.Http;\n  7  using System.Web.Mvc;\n  8  using System.Web.Optimization;\n  9  using System.Web.Routing;\n 10  \n 11  namespace NerdDinner\n 12  {\n 13      // Note: For instructions on enabling IIS6 or IIS7 classic mode, \n 14      // visit http://go.microsoft.com/?LinkId=9394801\n 15  \n 16      public class MvcApplication : System.Web.HttpApplication\n 17      {\n 18          protected void Application_Start()"
+        lineNumber: 7
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
+          fqdn_namespace: System.Web.Optimization
+          symbol: System.Web.Optimization
+          syntax_type: import
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
+        message: |
+          System.Web.Optimization is not available in .NET Core.
+          Bundling and minification are handled differently in ASP.NET Core.
+
+          Migration actions:
+          - Remove BundleConfig.cs
+          - Use BuildBundlerMinifier NuGet package, or
+          - Use Webpack, Gulp, or other build-time bundlers, or
+          - Use ASP.NET Core bundling libraries like WebOptimizer
+          - Update views to reference individual files or new bundle definitions
+        codeSnip: " 15  \n 16      public class MvcApplication : System.Web.HttpApplication\n 17      {\n 18          protected void Application_Start()\n 19          {\n 20              AreaRegistration.RegisterAllAreas();\n 21  \n 22              WebApiConfig.Register(GlobalConfiguration.Configuration);\n 23              FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);\n 24              RouteConfig.RegisterRoutes(RouteTable.Routes);\n 25              BundleConfig.RegisterBundles(BundleTable.Bundles);\n 26              AuthConfig.RegisterAuth();\n 27  \n 28              ModelBinderProviders.BinderProviders.Add(new EFModelBinderProvider());\n 29  \n 30              Version version = Assembly.GetExecutingAssembly().GetName().Version;\n 31              Application[\"Version\"] = string.Format(\"{0}.{1}\", version.Major, version.Minor);\n 32          }\n 33      }\n 34  }"
+        lineNumber: 24
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
+          fqdn_class: BundleCollection
+          fqdn_namespace: System.Web.Optimization
+          symbol: BundleTable.Bundles
+          syntax_type: type_usage
+        isDependencyIncident: false
+      links:
+      - url: https://learn.microsoft.com/en-us/aspnet/core/client-side/bundling-and-minification
+        title: Bundle and minify static assets in ASP.NET Core
+      effort: 5
+    dotnet-core-routing-01:
+      description: System.Web.Routing is replaced by ASP.NET Core routing
+      category: mandatory
+      labels:
+      - konveyor.io/source=dotnet
+      - konveyor.io/target=dotnet-core
+      incidents:
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/RouteConfig.cs
+        message: |
+          System.Web.Routing is not available in .NET Core and is replaced by ASP.NET Core routing.
+
+          Migration actions:
+          - Move route registration from RouteConfig.RegisterRoutes to Startup.Configure
+          - Use app.UseRouting() and app.UseEndpoints() in the middleware pipeline
+          - Consider using endpoint routing with MapControllerRoute
+          - Update any custom route constraints
+        codeSnip: "  1  using System;\n  2  using System.Collections.Generic;\n  3  using System.Linq;\n  4  using System.Web;\n  5  using System.Web.Mvc;\n  6  using System.Web.Routing;\n  7  \n  8  namespace NerdDinner\n  9  {\n 10      public class RouteConfig\n 11      {\n 12          public static void RegisterRoutes(RouteCollection routes)\n 13          {\n 14              routes.IgnoreRoute(\"{resource}.axd/{*pathInfo}\");\n 15  \n 16              routes.MapRoute("
+        lineNumber: 5
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/RouteConfig.cs
+          fqdn_namespace: System.Web.Routing
+          symbol: System.Web.Routing
+          syntax_type: import
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/RouteConfig.cs
+        message: |
+          System.Web.Routing is not available in .NET Core and is replaced by ASP.NET Core routing.
+
+          Migration actions:
+          - Move route registration from RouteConfig.RegisterRoutes to Startup.Configure
+          - Use app.UseRouting() and app.UseEndpoints() in the middleware pipeline
+          - Consider using endpoint routing with MapControllerRoute
+          - Update any custom route constraints
+        codeSnip: "  2  using System.Collections.Generic;\n  3  using System.Linq;\n  4  using System.Web;\n  5  using System.Web.Mvc;\n  6  using System.Web.Routing;\n  7  \n  8  namespace NerdDinner\n  9  {\n 10      public class RouteConfig\n 11      {\n 12          public static void RegisterRoutes(RouteCollection routes)\n 13          {\n 14              routes.IgnoreRoute(\"{resource}.axd/{*pathInfo}\");\n 15  \n 16              routes.MapRoute(\n 17                      \"PrettyDetails\",\n 18                      \"{Id}\",\n 19                          new { controller = \"Dinners\", action = \"Details\" },\n 20                          new { Id = @\"\\d+\" }\n 21                      );\n 22  "
+        lineNumber: 11
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/RouteConfig.cs
+          fqdn_class: RouteCollection
+          fqdn_namespace: System.Web.Routing
+          symbol: RouteCollection
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
+        message: |
+          System.Web.Routing is not available in .NET Core and is replaced by ASP.NET Core routing.
+
+          Migration actions:
+          - Move route registration from RouteConfig.RegisterRoutes to Startup.Configure
+          - Use app.UseRouting() and app.UseEndpoints() in the middleware pipeline
+          - Consider using endpoint routing with MapControllerRoute
+          - Update any custom route constraints
+        codeSnip: "  1  using System;\n  2  using System.Collections.Generic;\n  3  using System.Linq;\n  4  using System.Reflection;\n  5  using System.Web;\n  6  using System.Web.Http;\n  7  using System.Web.Mvc;\n  8  using System.Web.Optimization;\n  9  using System.Web.Routing;\n 10  \n 11  namespace NerdDinner\n 12  {\n 13      // Note: For instructions on enabling IIS6 or IIS7 classic mode, \n 14      // visit http://go.microsoft.com/?LinkId=9394801\n 15  \n 16      public class MvcApplication : System.Web.HttpApplication\n 17      {\n 18          protected void Application_Start()\n 19          {"
+        lineNumber: 8
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
+          fqdn_namespace: System.Web.Routing
+          symbol: System.Web.Routing
+          syntax_type: import
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
+        message: |
+          System.Web.Routing is not available in .NET Core and is replaced by ASP.NET Core routing.
+
+          Migration actions:
+          - Move route registration from RouteConfig.RegisterRoutes to Startup.Configure
+          - Use app.UseRouting() and app.UseEndpoints() in the middleware pipeline
+          - Consider using endpoint routing with MapControllerRoute
+          - Update any custom route constraints
+        codeSnip: " 14      // visit http://go.microsoft.com/?LinkId=9394801\n 15  \n 16      public class MvcApplication : System.Web.HttpApplication\n 17      {\n 18          protected void Application_Start()\n 19          {\n 20              AreaRegistration.RegisterAllAreas();\n 21  \n 22              WebApiConfig.Register(GlobalConfiguration.Configuration);\n 23              FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);\n 24              RouteConfig.RegisterRoutes(RouteTable.Routes);\n 25              BundleConfig.RegisterBundles(BundleTable.Bundles);\n 26              AuthConfig.RegisterAuth();\n 27  \n 28              ModelBinderProviders.BinderProviders.Add(new EFModelBinderProvider());\n 29  \n 30              Version version = Assembly.GetExecutingAssembly().GetName().Version;\n 31              Application[\"Version\"] = string.Format(\"{0}.{1}\", version.Major, version.Minor);\n 32          }\n 33      }\n 34  }"
+        lineNumber: 23
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
+          fqdn_class: RouteCollection
+          fqdn_namespace: System.Web.Routing
+          symbol: RouteTable.Routes
+          syntax_type: type_usage
+        isDependencyIncident: false
+      links:
+      - url: https://learn.microsoft.com/en-us/aspnet/core/fundamentals/routing
+        title: Routing in ASP.NET Core
+      effort: 5
+    dotnet-core-transactionscope-01:
+      description: System.Transactions.TransactionScope requires configuration in .NET Core
+      category: mandatory
+      labels:
+      - konveyor.io/source=dotnet
+      - konveyor.io/target=dotnet-core
+      incidents:
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          System.Transactions.TransactionScope is available in .NET Core but with limitations.
+          Distributed transactions are not supported on all platforms.
+
+          Migration actions:
+          - Review usage of distributed transactions - they may not work on Linux/macOS
+          - Consider using database transactions instead (DbContext.Database.BeginTransaction)
+          - For distributed scenarios on Windows, add System.Transactions.Local package
+          - Test transaction behavior on target platform
+        codeSnip: "100          [ValidateAntiForgeryToken]\n101          public ActionResult Disassociate(string provider, string providerUserId)\n102          {\n103              string ownerAccount = OAuthWebSecurity.GetUserName(provider, providerUserId);\n104              ManageMessageId? message = null;\n105  \n106              // Only disassociate the account if the currently logged in user is the owner\n107              if (ownerAccount == User.Identity.Name)\n108              {\n109                  // Use a transaction to prevent the user from deleting their last login credential\n110                  using (var scope = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions { IsolationLevel = IsolationLevel.Serializable }))\n111                  {\n112                      bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n113                      if (hasLocalAccount || OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name).Count > 1)\n114                      {\n115                          OAuthWebSecurity.DeleteAccount(provider, providerUserId);\n116                          scope.Complete();\n117                          message = ManageMessageId.RemoveLoginSuccess;\n118                      }\n119                  }\n120              }"
+        lineNumber: 109
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: TransactionScope
+          fqdn_namespace: System.Transactions
+          symbol: TransactionScope
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          System.Transactions.TransactionScope is available in .NET Core but with limitations.
+          Distributed transactions are not supported on all platforms.
+
+          Migration actions:
+          - Review usage of distributed transactions - they may not work on Linux/macOS
+          - Consider using database transactions instead (DbContext.Database.BeginTransaction)
+          - For distributed scenarios on Windows, add System.Transactions.Local package
+          - Test transaction behavior on target platform
+        codeSnip: "106              // Only disassociate the account if the currently logged in user is the owner\n107              if (ownerAccount == User.Identity.Name)\n108              {\n109                  // Use a transaction to prevent the user from deleting their last login credential\n110                  using (var scope = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions { IsolationLevel = IsolationLevel.Serializable }))\n111                  {\n112                      bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n113                      if (hasLocalAccount || OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name).Count > 1)\n114                      {\n115                          OAuthWebSecurity.DeleteAccount(provider, providerUserId);\n116                          scope.Complete();\n117                          message = ManageMessageId.RemoveLoginSuccess;\n118                      }\n119                  }\n120              }\n121  \n122              return RedirectToAction(\"Manage\", new { Message = message });\n123          }\n124  \n125          //\n126          // GET: /Account/Manage"
+        lineNumber: 115
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: TransactionScope
+          fqdn_method: Complete
+          fqdn_namespace: System.Transactions
+          symbol: scope.Complete
+          syntax_type: method_reference
+        isDependencyIncident: false
+      links:
+      - url: https://learn.microsoft.com/en-us/dotnet/api/system.transactions
+        title: System.Transactions in .NET Core
+      effort: 3
+    dotnet-core-webapi-controller-01:
+      description: System.Web.Http.ApiController must be replaced with ASP.NET Core API controller
+      category: mandatory
+      labels:
+      - konveyor.io/source=dotnet
+      - konveyor.io/target=dotnet-core
+      incidents:
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/SearchController.cs
+        message: |
+          System.Web.Http.ApiController is replaced by Microsoft.AspNetCore.Mvc.ControllerBase in ASP.NET Core.
+
+          Migration actions:
+          - Change base class from ApiController to ControllerBase
+          - Change using from System.Web.Http to Microsoft.AspNetCore.Mvc
+          - Add [ApiController] attribute to controller classes
+          - Update response types to use ActionResult<T> pattern
+          - Review routing (Web API routing differs from ASP.NET Core)
+        codeSnip: " 16          public int DinnerID { get; set; }\n 17          public DateTime EventDate { get; set; }\n 18          public string Title { get; set; }\n 19          public double Latitude { get; set; }\n 20          public double Longitude { get; set; }\n 21          public string Description { get; set; }\n 22          public int RSVPCount { get; set; }\n 23          public string Url { get; set; }\n 24      }\n 25  \n 26      public class SearchController : ApiController\n 27      {\n 28          private NerdDinnerContext db = new NerdDinnerContext();\n 29  \n 30          // GET api/Search?latitude=1.0&longitude=1.0\n 31          [HttpGet]\n 32          public IEnumerable<JsonDinner> SearchByLocation(double latitude, double longitude)\n 33          {\n 34              return FindByLocation(latitude, longitude);\n 35          }\n 36  "
+        lineNumber: 25
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/SearchController.cs
+          fqdn_class: ApiController
+          fqdn_namespace: System.Web.Http
+          symbol: ApiController
+          syntax_type: type_reference
+        isDependencyIncident: false
+      links:
+      - url: https://learn.microsoft.com/en-us/aspnet/core/migration/webapi
+        title: Migrate Web API to ASP.NET Core
+      effort: 3
+    dotnet-core-webconfig-01:
+      description: System.Web.Configuration.WebConfigurationManager is not available in .NET Core
+      category: mandatory
+      labels:
+      - konveyor.io/source=dotnet
+      - konveyor.io/target=dotnet-core
+      incidents:
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
+        message: |
+          System.Web.Configuration.WebConfigurationManager is not available in .NET Core.
+          Configuration is handled differently using the configuration API and appsettings.json.
+
+          Migration actions:
+          - Move configuration from Web.config to appsettings.json
+          - Replace WebConfigurationManager.AppSettings with IConfiguration
+          - Inject IConfiguration into controllers or services
+          - Use IOptions<T> pattern for strongly-typed configuration
+          - Access app settings via Configuration["key"] or Configuration.GetValue<T>("key")
+          - Create configuration classes for complex settings
+        codeSnip: "  8  \n  9  namespace NerdDinner\n 10  {\n 11      public static class AuthConfig\n 12      {\n 13          public static void RegisterAuth()\n 14          {\n 15              // To let users of this site log in using their accounts from other sites such as Microsoft, Facebook, and Twitter,\n 16              // you must update this site. For more information visit http://go.microsoft.com/fwlink/?LinkID=252166\n 17  \n 18              var microsoftClientId = WebConfigurationManager.AppSettings[\"microsoftClientId\"];\n 19              var microsoftClientSecret = WebConfigurationManager.AppSettings[\"microsoftClientSecret\"];\n 20              if (!string.IsNullOrEmpty(microsoftClientId) && !string.IsNullOrEmpty(microsoftClientSecret))\n 21              {\n 22                  OAuthWebSecurity.RegisterMicrosoftClient(\n 23                      clientId: microsoftClientId,\n 24                      clientSecret: microsoftClientSecret);\n 25              }\n 26  \n 27              var twitterConsumerKey = WebConfigurationManager.AppSettings[\"twitterConsumerKey\"];\n 28              var twitterConsumerSecret = WebConfigurationManager.AppSettings[\"twitterConsumerSecret\"];"
+        lineNumber: 17
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
+          fqdn_class: WebConfigurationManager
+          fqdn_field: AppSettings
+          fqdn_namespace: System.Web.Configuration
+          symbol: WebConfigurationManager.AppSettings
+          syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
+        message: |
+          System.Web.Configuration.WebConfigurationManager is not available in .NET Core.
+          Configuration is handled differently using the configuration API and appsettings.json.
+
+          Migration actions:
+          - Move configuration from Web.config to appsettings.json
+          - Replace WebConfigurationManager.AppSettings with IConfiguration
+          - Inject IConfiguration into controllers or services
+          - Use IOptions<T> pattern for strongly-typed configuration
+          - Access app settings via Configuration["key"] or Configuration.GetValue<T>("key")
+          - Create configuration classes for complex settings
+        codeSnip: "  9  namespace NerdDinner\n 10  {\n 11      public static class AuthConfig\n 12      {\n 13          public static void RegisterAuth()\n 14          {\n 15              // To let users of this site log in using their accounts from other sites such as Microsoft, Facebook, and Twitter,\n 16              // you must update this site. For more information visit http://go.microsoft.com/fwlink/?LinkID=252166\n 17  \n 18              var microsoftClientId = WebConfigurationManager.AppSettings[\"microsoftClientId\"];\n 19              var microsoftClientSecret = WebConfigurationManager.AppSettings[\"microsoftClientSecret\"];\n 20              if (!string.IsNullOrEmpty(microsoftClientId) && !string.IsNullOrEmpty(microsoftClientSecret))\n 21              {\n 22                  OAuthWebSecurity.RegisterMicrosoftClient(\n 23                      clientId: microsoftClientId,\n 24                      clientSecret: microsoftClientSecret);\n 25              }\n 26  \n 27              var twitterConsumerKey = WebConfigurationManager.AppSettings[\"twitterConsumerKey\"];\n 28              var twitterConsumerSecret = WebConfigurationManager.AppSettings[\"twitterConsumerSecret\"];\n 29              if (!string.IsNullOrEmpty(twitterConsumerKey) && !string.IsNullOrEmpty(twitterConsumerSecret))"
+        lineNumber: 18
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
+          fqdn_class: WebConfigurationManager
+          fqdn_field: AppSettings
+          fqdn_namespace: System.Web.Configuration
+          symbol: WebConfigurationManager.AppSettings
+          syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
+        message: |
+          System.Web.Configuration.WebConfigurationManager is not available in .NET Core.
+          Configuration is handled differently using the configuration API and appsettings.json.
+
+          Migration actions:
+          - Move configuration from Web.config to appsettings.json
+          - Replace WebConfigurationManager.AppSettings with IConfiguration
+          - Inject IConfiguration into controllers or services
+          - Use IOptions<T> pattern for strongly-typed configuration
+          - Access app settings via Configuration["key"] or Configuration.GetValue<T>("key")
+          - Create configuration classes for complex settings
+        codeSnip: " 17  \n 18              var microsoftClientId = WebConfigurationManager.AppSettings[\"microsoftClientId\"];\n 19              var microsoftClientSecret = WebConfigurationManager.AppSettings[\"microsoftClientSecret\"];\n 20              if (!string.IsNullOrEmpty(microsoftClientId) && !string.IsNullOrEmpty(microsoftClientSecret))\n 21              {\n 22                  OAuthWebSecurity.RegisterMicrosoftClient(\n 23                      clientId: microsoftClientId,\n 24                      clientSecret: microsoftClientSecret);\n 25              }\n 26  \n 27              var twitterConsumerKey = WebConfigurationManager.AppSettings[\"twitterConsumerKey\"];\n 28              var twitterConsumerSecret = WebConfigurationManager.AppSettings[\"twitterConsumerSecret\"];\n 29              if (!string.IsNullOrEmpty(twitterConsumerKey) && !string.IsNullOrEmpty(twitterConsumerSecret))\n 30              {\n 31                  OAuthWebSecurity.RegisterTwitterClient(\n 32                      consumerKey: twitterConsumerKey,\n 33                      consumerSecret: twitterConsumerSecret);\n 34              }\n 35  \n 36              var facebookAppId = WebConfigurationManager.AppSettings[\"facebookAppId\"];\n 37              var facebookAppSecret = WebConfigurationManager.AppSettings[\"facebookAppSecret\"];"
+        lineNumber: 26
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
+          fqdn_class: WebConfigurationManager
+          fqdn_field: AppSettings
+          fqdn_namespace: System.Web.Configuration
+          symbol: WebConfigurationManager.AppSettings
+          syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
+        message: |
+          System.Web.Configuration.WebConfigurationManager is not available in .NET Core.
+          Configuration is handled differently using the configuration API and appsettings.json.
+
+          Migration actions:
+          - Move configuration from Web.config to appsettings.json
+          - Replace WebConfigurationManager.AppSettings with IConfiguration
+          - Inject IConfiguration into controllers or services
+          - Use IOptions<T> pattern for strongly-typed configuration
+          - Access app settings via Configuration["key"] or Configuration.GetValue<T>("key")
+          - Create configuration classes for complex settings
+        codeSnip: " 18              var microsoftClientId = WebConfigurationManager.AppSettings[\"microsoftClientId\"];\n 19              var microsoftClientSecret = WebConfigurationManager.AppSettings[\"microsoftClientSecret\"];\n 20              if (!string.IsNullOrEmpty(microsoftClientId) && !string.IsNullOrEmpty(microsoftClientSecret))\n 21              {\n 22                  OAuthWebSecurity.RegisterMicrosoftClient(\n 23                      clientId: microsoftClientId,\n 24                      clientSecret: microsoftClientSecret);\n 25              }\n 26  \n 27              var twitterConsumerKey = WebConfigurationManager.AppSettings[\"twitterConsumerKey\"];\n 28              var twitterConsumerSecret = WebConfigurationManager.AppSettings[\"twitterConsumerSecret\"];\n 29              if (!string.IsNullOrEmpty(twitterConsumerKey) && !string.IsNullOrEmpty(twitterConsumerSecret))\n 30              {\n 31                  OAuthWebSecurity.RegisterTwitterClient(\n 32                      consumerKey: twitterConsumerKey,\n 33                      consumerSecret: twitterConsumerSecret);\n 34              }\n 35  \n 36              var facebookAppId = WebConfigurationManager.AppSettings[\"facebookAppId\"];\n 37              var facebookAppSecret = WebConfigurationManager.AppSettings[\"facebookAppSecret\"];\n 38              if (!string.IsNullOrEmpty(facebookAppId) && !string.IsNullOrEmpty(facebookAppSecret))"
+        lineNumber: 27
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
+          fqdn_class: WebConfigurationManager
+          fqdn_field: AppSettings
+          fqdn_namespace: System.Web.Configuration
+          symbol: WebConfigurationManager.AppSettings
+          syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
+        message: |
+          System.Web.Configuration.WebConfigurationManager is not available in .NET Core.
+          Configuration is handled differently using the configuration API and appsettings.json.
+
+          Migration actions:
+          - Move configuration from Web.config to appsettings.json
+          - Replace WebConfigurationManager.AppSettings with IConfiguration
+          - Inject IConfiguration into controllers or services
+          - Use IOptions<T> pattern for strongly-typed configuration
+          - Access app settings via Configuration["key"] or Configuration.GetValue<T>("key")
+          - Create configuration classes for complex settings
+        codeSnip: " 26  \n 27              var twitterConsumerKey = WebConfigurationManager.AppSettings[\"twitterConsumerKey\"];\n 28              var twitterConsumerSecret = WebConfigurationManager.AppSettings[\"twitterConsumerSecret\"];\n 29              if (!string.IsNullOrEmpty(twitterConsumerKey) && !string.IsNullOrEmpty(twitterConsumerSecret))\n 30              {\n 31                  OAuthWebSecurity.RegisterTwitterClient(\n 32                      consumerKey: twitterConsumerKey,\n 33                      consumerSecret: twitterConsumerSecret);\n 34              }\n 35  \n 36              var facebookAppId = WebConfigurationManager.AppSettings[\"facebookAppId\"];\n 37              var facebookAppSecret = WebConfigurationManager.AppSettings[\"facebookAppSecret\"];\n 38              if (!string.IsNullOrEmpty(facebookAppId) && !string.IsNullOrEmpty(facebookAppSecret))\n 39              {\n 40                  OAuthWebSecurity.RegisterFacebookClient(\n 41                      appId: facebookAppId,\n 42                      appSecret: facebookAppSecret);\n 43              }\n 44  \n 45              OAuthWebSecurity.RegisterGoogleClient();\n 46          }"
+        lineNumber: 35
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
+          fqdn_class: WebConfigurationManager
+          fqdn_field: AppSettings
+          fqdn_namespace: System.Web.Configuration
+          symbol: WebConfigurationManager.AppSettings
+          syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
+        message: |
+          System.Web.Configuration.WebConfigurationManager is not available in .NET Core.
+          Configuration is handled differently using the configuration API and appsettings.json.
+
+          Migration actions:
+          - Move configuration from Web.config to appsettings.json
+          - Replace WebConfigurationManager.AppSettings with IConfiguration
+          - Inject IConfiguration into controllers or services
+          - Use IOptions<T> pattern for strongly-typed configuration
+          - Access app settings via Configuration["key"] or Configuration.GetValue<T>("key")
+          - Create configuration classes for complex settings
+        codeSnip: " 27              var twitterConsumerKey = WebConfigurationManager.AppSettings[\"twitterConsumerKey\"];\n 28              var twitterConsumerSecret = WebConfigurationManager.AppSettings[\"twitterConsumerSecret\"];\n 29              if (!string.IsNullOrEmpty(twitterConsumerKey) && !string.IsNullOrEmpty(twitterConsumerSecret))\n 30              {\n 31                  OAuthWebSecurity.RegisterTwitterClient(\n 32                      consumerKey: twitterConsumerKey,\n 33                      consumerSecret: twitterConsumerSecret);\n 34              }\n 35  \n 36              var facebookAppId = WebConfigurationManager.AppSettings[\"facebookAppId\"];\n 37              var facebookAppSecret = WebConfigurationManager.AppSettings[\"facebookAppSecret\"];\n 38              if (!string.IsNullOrEmpty(facebookAppId) && !string.IsNullOrEmpty(facebookAppSecret))\n 39              {\n 40                  OAuthWebSecurity.RegisterFacebookClient(\n 41                      appId: facebookAppId,\n 42                      appSecret: facebookAppSecret);\n 43              }\n 44  \n 45              OAuthWebSecurity.RegisterGoogleClient();\n 46          }\n 47      }"
+        lineNumber: 36
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/AuthConfig.cs
+          fqdn_class: WebConfigurationManager
+          fqdn_field: AppSettings
+          fqdn_namespace: System.Web.Configuration
+          symbol: WebConfigurationManager.AppSettings
+          syntax_type: field_reference
+        isDependencyIncident: false
+      links:
+      - url: https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/
+        title: Configuration in ASP.NET Core
+      effort: 5
     dotnet-core-websecurity-01:
       description: WebMatrix.WebData.WebSecurity is not available in .NET Core
       category: mandatory
@@ -684,7 +2598,7 @@
           - Replace WebSecurity.CreateUserAndAccount with UserManager.CreateAsync
           - Replace WebSecurity.ChangePassword with UserManager.ChangePasswordAsync
           - Configure Identity in Startup.ConfigureServices with AddIdentity or AddDefaultIdentity
-        codeSnip: "27         }\n28 \n29         //\n30         // POST: /Account/Login\n31 \n32         [HttpPost]\n33         [AllowAnonymous]\n34         [ValidateAntiForgeryToken]\n35         public ActionResult Login(LoginModel model, string returnUrl)\n36         {\n37             if (ModelState.IsValid && WebSecurity.Login(model.UserName, model.Password, persistCookie: model.RememberMe))\n38             {\n39                 return RedirectToLocal(returnUrl);\n40             }\n41 \n42             // If we got this far, something failed, redisplay form\n43             ModelState.AddModelError(\"\", \"The user name or password provided is incorrect.\");\n44             return View(model);\n45         }\n46 \n47         //\n"
+        codeSnip: " 28          }\n 29  \n 30          //\n 31          // POST: /Account/Login\n 32  \n 33          [HttpPost]\n 34          [AllowAnonymous]\n 35          [ValidateAntiForgeryToken]\n 36          public ActionResult Login(LoginModel model, string returnUrl)\n 37          {\n 38              if (ModelState.IsValid && WebSecurity.Login(model.UserName, model.Password, persistCookie: model.RememberMe))\n 39              {\n 40                  return RedirectToLocal(returnUrl);\n 41              }\n 42  \n 43              // If we got this far, something failed, redisplay form\n 44              ModelState.AddModelError(\"\", \"The user name or password provided is incorrect.\");\n 45              return View(model);\n 46          }\n 47  \n 48          //"
         lineNumber: 37
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -693,6 +2607,7 @@
           fqdn_namespace: WebMatrix.WebData
           symbol: WebSecurity.Login
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           WebMatrix.WebData.WebSecurity is not available in .NET Core and must be replaced with ASP.NET Core Identity.
@@ -706,7 +2621,7 @@
           - Replace WebSecurity.CreateUserAndAccount with UserManager.CreateAsync
           - Replace WebSecurity.ChangePassword with UserManager.ChangePasswordAsync
           - Configure Identity in Startup.ConfigureServices with AddIdentity or AddDefaultIdentity
-        codeSnip: "44             return View(model);\n45         }\n46 \n47         //\n48         // POST: /Account/LogOff\n49 \n50         [HttpPost]\n51         [ValidateAntiForgeryToken]\n52         public ActionResult LogOff()\n53         {\n54             WebSecurity.Logout();\n55 \n56             return RedirectToAction(\"Index\", \"Home\");\n57         }\n58 \n59         //\n60         // GET: /Account/Register\n61 \n62         [AllowAnonymous]\n63         public ActionResult Register()\n64         {\n"
+        codeSnip: " 45              return View(model);\n 46          }\n 47  \n 48          //\n 49          // POST: /Account/LogOff\n 50  \n 51          [HttpPost]\n 52          [ValidateAntiForgeryToken]\n 53          public ActionResult LogOff()\n 54          {\n 55              WebSecurity.Logout();\n 56  \n 57              return RedirectToAction(\"Index\", \"Home\");\n 58          }\n 59  \n 60          //\n 61          // GET: /Account/Register\n 62  \n 63          [AllowAnonymous]\n 64          public ActionResult Register()\n 65          {"
         lineNumber: 54
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -715,6 +2630,7 @@
           fqdn_namespace: WebMatrix.WebData
           symbol: WebSecurity.Logout
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           WebMatrix.WebData.WebSecurity is not available in .NET Core and must be replaced with ASP.NET Core Identity.
@@ -728,7 +2644,7 @@
           - Replace WebSecurity.CreateUserAndAccount with UserManager.CreateAsync
           - Replace WebSecurity.ChangePassword with UserManager.ChangePasswordAsync
           - Configure Identity in Startup.ConfigureServices with AddIdentity or AddDefaultIdentity
-        codeSnip: "71         [HttpPost]\n72         [AllowAnonymous]\n73         [ValidateAntiForgeryToken]\n74         public ActionResult Register(RegisterModel model)\n75         {\n76             if (ModelState.IsValid)\n77             {\n78                 // Attempt to register the user\n79                 try\n80                 {\n81                     WebSecurity.CreateUserAndAccount(model.UserName, model.Password);\n82                     WebSecurity.Login(model.UserName, model.Password);\n83                     return RedirectToAction(\"Index\", \"Home\");\n84                 }\n85                 catch (MembershipCreateUserException e)\n86                 {\n87                     ModelState.AddModelError(\"\", ErrorCodeToString(e.StatusCode));\n88                 }\n89             }\n90 \n91             // If we got this far, something failed, redisplay form\n"
+        codeSnip: " 72          [HttpPost]\n 73          [AllowAnonymous]\n 74          [ValidateAntiForgeryToken]\n 75          public ActionResult Register(RegisterModel model)\n 76          {\n 77              if (ModelState.IsValid)\n 78              {\n 79                  // Attempt to register the user\n 80                  try\n 81                  {\n 82                      WebSecurity.CreateUserAndAccount(model.UserName, model.Password);\n 83                      WebSecurity.Login(model.UserName, model.Password);\n 84                      return RedirectToAction(\"Index\", \"Home\");\n 85                  }\n 86                  catch (MembershipCreateUserException e)\n 87                  {\n 88                      ModelState.AddModelError(\"\", ErrorCodeToString(e.StatusCode));\n 89                  }\n 90              }\n 91  \n 92              // If we got this far, something failed, redisplay form"
         lineNumber: 81
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -737,6 +2653,7 @@
           fqdn_namespace: WebMatrix.WebData
           symbol: WebSecurity.CreateUserAndAccount
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           WebMatrix.WebData.WebSecurity is not available in .NET Core and must be replaced with ASP.NET Core Identity.
@@ -750,7 +2667,7 @@
           - Replace WebSecurity.CreateUserAndAccount with UserManager.CreateAsync
           - Replace WebSecurity.ChangePassword with UserManager.ChangePasswordAsync
           - Configure Identity in Startup.ConfigureServices with AddIdentity or AddDefaultIdentity
-        codeSnip: "72         [AllowAnonymous]\n73         [ValidateAntiForgeryToken]\n74         public ActionResult Register(RegisterModel model)\n75         {\n76             if (ModelState.IsValid)\n77             {\n78                 // Attempt to register the user\n79                 try\n80                 {\n81                     WebSecurity.CreateUserAndAccount(model.UserName, model.Password);\n82                     WebSecurity.Login(model.UserName, model.Password);\n83                     return RedirectToAction(\"Index\", \"Home\");\n84                 }\n85                 catch (MembershipCreateUserException e)\n86                 {\n87                     ModelState.AddModelError(\"\", ErrorCodeToString(e.StatusCode));\n88                 }\n89             }\n90 \n91             // If we got this far, something failed, redisplay form\n92             return View(model);\n"
+        codeSnip: " 73          [AllowAnonymous]\n 74          [ValidateAntiForgeryToken]\n 75          public ActionResult Register(RegisterModel model)\n 76          {\n 77              if (ModelState.IsValid)\n 78              {\n 79                  // Attempt to register the user\n 80                  try\n 81                  {\n 82                      WebSecurity.CreateUserAndAccount(model.UserName, model.Password);\n 83                      WebSecurity.Login(model.UserName, model.Password);\n 84                      return RedirectToAction(\"Index\", \"Home\");\n 85                  }\n 86                  catch (MembershipCreateUserException e)\n 87                  {\n 88                      ModelState.AddModelError(\"\", ErrorCodeToString(e.StatusCode));\n 89                  }\n 90              }\n 91  \n 92              // If we got this far, something failed, redisplay form\n 93              return View(model);"
         lineNumber: 82
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -759,6 +2676,7 @@
           fqdn_namespace: WebMatrix.WebData
           symbol: WebSecurity.Login
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           WebMatrix.WebData.WebSecurity is not available in .NET Core and must be replaced with ASP.NET Core Identity.
@@ -772,7 +2690,7 @@
           - Replace WebSecurity.CreateUserAndAccount with UserManager.CreateAsync
           - Replace WebSecurity.ChangePassword with UserManager.ChangePasswordAsync
           - Configure Identity in Startup.ConfigureServices with AddIdentity or AddDefaultIdentity
-        codeSnip: "101         {\n102             string ownerAccount = OAuthWebSecurity.GetUserName(provider, providerUserId);\n103             ManageMessageId? message = null;\n104 \n105             // Only disassociate the account if the currently logged in user is the owner\n106             if (ownerAccount == User.Identity.Name)\n107             {\n108                 // Use a transaction to prevent the user from deleting their last login credential\n109                 using (var scope = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions { IsolationLevel = IsolationLevel.Serializable }))\n110                 {\n111                     bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n112                     if (hasLocalAccount || OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name).Count > 1)\n113                     {\n114                         OAuthWebSecurity.DeleteAccount(provider, providerUserId);\n115                         scope.Complete();\n116                         message = ManageMessageId.RemoveLoginSuccess;\n117                     }\n118                 }\n119             }\n120 \n121             return RedirectToAction(\"Manage\", new { Message = message });\n"
+        codeSnip: "102          {\n103              string ownerAccount = OAuthWebSecurity.GetUserName(provider, providerUserId);\n104              ManageMessageId? message = null;\n105  \n106              // Only disassociate the account if the currently logged in user is the owner\n107              if (ownerAccount == User.Identity.Name)\n108              {\n109                  // Use a transaction to prevent the user from deleting their last login credential\n110                  using (var scope = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions { IsolationLevel = IsolationLevel.Serializable }))\n111                  {\n112                      bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n113                      if (hasLocalAccount || OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name).Count > 1)\n114                      {\n115                          OAuthWebSecurity.DeleteAccount(provider, providerUserId);\n116                          scope.Complete();\n117                          message = ManageMessageId.RemoveLoginSuccess;\n118                      }\n119                  }\n120              }\n121  \n122              return RedirectToAction(\"Manage\", new { Message = message });"
         lineNumber: 111
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -781,6 +2699,7 @@
           fqdn_namespace: WebMatrix.WebData
           symbol: WebSecurity.GetUserId
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           WebMatrix.WebData.WebSecurity is not available in .NET Core and must be replaced with ASP.NET Core Identity.
@@ -794,7 +2713,7 @@
           - Replace WebSecurity.CreateUserAndAccount with UserManager.CreateAsync
           - Replace WebSecurity.ChangePassword with UserManager.ChangePasswordAsync
           - Configure Identity in Startup.ConfigureServices with AddIdentity or AddDefaultIdentity
-        codeSnip: "124         //\n125         // GET: /Account/Manage\n126 \n127         public ActionResult Manage(ManageMessageId? message)\n128         {\n129             ViewBag.StatusMessage =\n130                 message == ManageMessageId.ChangePasswordSuccess ? \"Your password has been changed.\"\n131                 : message == ManageMessageId.SetPasswordSuccess ? \"Your password has been set.\"\n132                 : message == ManageMessageId.RemoveLoginSuccess ? \"The external login was removed.\"\n133                 : \"\";\n134             ViewBag.HasLocalPassword = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n135             ViewBag.ReturnUrl = Url.Action(\"Manage\");\n136             return View();\n137         }\n138 \n139         //\n140         // POST: /Account/Manage\n141 \n142         [HttpPost]\n143         [ValidateAntiForgeryToken]\n144         public ActionResult Manage(LocalPasswordModel model)\n"
+        codeSnip: "125          //\n126          // GET: /Account/Manage\n127  \n128          public ActionResult Manage(ManageMessageId? message)\n129          {\n130              ViewBag.StatusMessage =\n131                  message == ManageMessageId.ChangePasswordSuccess ? \"Your password has been changed.\"\n132                  : message == ManageMessageId.SetPasswordSuccess ? \"Your password has been set.\"\n133                  : message == ManageMessageId.RemoveLoginSuccess ? \"The external login was removed.\"\n134                  : \"\";\n135              ViewBag.HasLocalPassword = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n136              ViewBag.ReturnUrl = Url.Action(\"Manage\");\n137              return View();\n138          }\n139  \n140          //\n141          // POST: /Account/Manage\n142  \n143          [HttpPost]\n144          [ValidateAntiForgeryToken]\n145          public ActionResult Manage(LocalPasswordModel model)"
         lineNumber: 134
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -803,6 +2722,7 @@
           fqdn_namespace: WebMatrix.WebData
           symbol: WebSecurity.GetUserId
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           WebMatrix.WebData.WebSecurity is not available in .NET Core and must be replaced with ASP.NET Core Identity.
@@ -816,7 +2736,7 @@
           - Replace WebSecurity.CreateUserAndAccount with UserManager.CreateAsync
           - Replace WebSecurity.ChangePassword with UserManager.ChangePasswordAsync
           - Configure Identity in Startup.ConfigureServices with AddIdentity or AddDefaultIdentity
-        codeSnip: "136             return View();\n137         }\n138 \n139         //\n140         // POST: /Account/Manage\n141 \n142         [HttpPost]\n143         [ValidateAntiForgeryToken]\n144         public ActionResult Manage(LocalPasswordModel model)\n145         {\n146             bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n147             ViewBag.HasLocalPassword = hasLocalAccount;\n148             ViewBag.ReturnUrl = Url.Action(\"Manage\");\n149             if (hasLocalAccount)\n150             {\n151                 if (ModelState.IsValid)\n152                 {\n153                     // ChangePassword will throw an exception rather than return false in certain failure scenarios.\n154                     bool changePasswordSucceeded;\n155                     try\n156                     {\n"
+        codeSnip: "137              return View();\n138          }\n139  \n140          //\n141          // POST: /Account/Manage\n142  \n143          [HttpPost]\n144          [ValidateAntiForgeryToken]\n145          public ActionResult Manage(LocalPasswordModel model)\n146          {\n147              bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n148              ViewBag.HasLocalPassword = hasLocalAccount;\n149              ViewBag.ReturnUrl = Url.Action(\"Manage\");\n150              if (hasLocalAccount)\n151              {\n152                  if (ModelState.IsValid)\n153                  {\n154                      // ChangePassword will throw an exception rather than return false in certain failure scenarios.\n155                      bool changePasswordSucceeded;\n156                      try\n157                      {"
         lineNumber: 146
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -825,6 +2745,7 @@
           fqdn_namespace: WebMatrix.WebData
           symbol: WebSecurity.GetUserId
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           WebMatrix.WebData.WebSecurity is not available in .NET Core and must be replaced with ASP.NET Core Identity.
@@ -838,7 +2759,7 @@
           - Replace WebSecurity.CreateUserAndAccount with UserManager.CreateAsync
           - Replace WebSecurity.ChangePassword with UserManager.ChangePasswordAsync
           - Configure Identity in Startup.ConfigureServices with AddIdentity or AddDefaultIdentity
-        codeSnip: "147             ViewBag.HasLocalPassword = hasLocalAccount;\n148             ViewBag.ReturnUrl = Url.Action(\"Manage\");\n149             if (hasLocalAccount)\n150             {\n151                 if (ModelState.IsValid)\n152                 {\n153                     // ChangePassword will throw an exception rather than return false in certain failure scenarios.\n154                     bool changePasswordSucceeded;\n155                     try\n156                     {\n157                         changePasswordSucceeded = WebSecurity.ChangePassword(User.Identity.Name, model.OldPassword, model.NewPassword);\n158                     }\n159                     catch (Exception)\n160                     {\n161                         changePasswordSucceeded = false;\n162                     }\n163 \n164                     if (changePasswordSucceeded)\n165                     {\n166                         return RedirectToAction(\"Manage\", new { Message = ManageMessageId.ChangePasswordSuccess });\n167                     }\n"
+        codeSnip: "148              ViewBag.HasLocalPassword = hasLocalAccount;\n149              ViewBag.ReturnUrl = Url.Action(\"Manage\");\n150              if (hasLocalAccount)\n151              {\n152                  if (ModelState.IsValid)\n153                  {\n154                      // ChangePassword will throw an exception rather than return false in certain failure scenarios.\n155                      bool changePasswordSucceeded;\n156                      try\n157                      {\n158                          changePasswordSucceeded = WebSecurity.ChangePassword(User.Identity.Name, model.OldPassword, model.NewPassword);\n159                      }\n160                      catch (Exception)\n161                      {\n162                          changePasswordSucceeded = false;\n163                      }\n164  \n165                      if (changePasswordSucceeded)\n166                      {\n167                          return RedirectToAction(\"Manage\", new { Message = ManageMessageId.ChangePasswordSuccess });\n168                      }"
         lineNumber: 157
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -847,6 +2768,7 @@
           fqdn_namespace: WebMatrix.WebData
           symbol: WebSecurity.ChangePassword
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           WebMatrix.WebData.WebSecurity is not available in .NET Core and must be replaced with ASP.NET Core Identity.
@@ -860,7 +2782,7 @@
           - Replace WebSecurity.CreateUserAndAccount with UserManager.CreateAsync
           - Replace WebSecurity.ChangePassword with UserManager.ChangePasswordAsync
           - Configure Identity in Startup.ConfigureServices with AddIdentity or AddDefaultIdentity
-        codeSnip: "178                 ModelState state = ModelState[\"OldPassword\"];\n179                 if (state != null)\n180                 {\n181                     state.Errors.Clear();\n182                 }\n183 \n184                 if (ModelState.IsValid)\n185                 {\n186                     try\n187                     {\n188                         WebSecurity.CreateAccount(User.Identity.Name, model.NewPassword);\n189                         return RedirectToAction(\"Manage\", new { Message = ManageMessageId.SetPasswordSuccess });\n190                     }\n191                     catch (Exception)\n192                     {\n193                         ModelState.AddModelError(\"\", String.Format(\"Unable to create local account. An account with the name \\\"{0}\\\" may already exist.\", User.Identity.Name));\n194                     }\n195                 }\n196             }\n197 \n198             // If we got this far, something failed, redisplay form\n"
+        codeSnip: "179                  ModelState state = ModelState[\"OldPassword\"];\n180                  if (state != null)\n181                  {\n182                      state.Errors.Clear();\n183                  }\n184  \n185                  if (ModelState.IsValid)\n186                  {\n187                      try\n188                      {\n189                          WebSecurity.CreateAccount(User.Identity.Name, model.NewPassword);\n190                          return RedirectToAction(\"Manage\", new { Message = ManageMessageId.SetPasswordSuccess });\n191                      }\n192                      catch (Exception)\n193                      {\n194                          ModelState.AddModelError(\"\", String.Format(\"Unable to create local account. An account with the name \\\"{0}\\\" may already exist.\", User.Identity.Name));\n195                      }\n196                  }\n197              }\n198  \n199              // If we got this far, something failed, redisplay form"
         lineNumber: 188
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -869,6 +2791,7 @@
           fqdn_namespace: WebMatrix.WebData
           symbol: WebSecurity.CreateAccount
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           WebMatrix.WebData.WebSecurity is not available in .NET Core and must be replaced with ASP.NET Core Identity.
@@ -882,7 +2805,7 @@
           - Replace WebSecurity.CreateUserAndAccount with UserManager.CreateAsync
           - Replace WebSecurity.ChangePassword with UserManager.ChangePasswordAsync
           - Configure Identity in Startup.ConfigureServices with AddIdentity or AddDefaultIdentity
-        codeSnip: "316                 AuthenticationClientData clientData = OAuthWebSecurity.GetOAuthClientData(account.Provider);\n317 \n318                 externalLogins.Add(new ExternalLogin\n319                 {\n320                     Provider = account.Provider,\n321                     ProviderDisplayName = clientData.DisplayName,\n322                     ProviderUserId = account.ProviderUserId,\n323                 });\n324             }\n325 \n326             ViewBag.ShowRemoveButton = externalLogins.Count > 1 || OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n327             return PartialView(\"_RemoveExternalLoginsPartial\", externalLogins);\n328         }\n329 \n330         #region Helpers\n331         private ActionResult RedirectToLocal(string returnUrl)\n332         {\n333             if (Url.IsLocalUrl(returnUrl))\n334             {\n335                 return Redirect(returnUrl);\n336             }\n"
+        codeSnip: "317                  AuthenticationClientData clientData = OAuthWebSecurity.GetOAuthClientData(account.Provider);\n318  \n319                  externalLogins.Add(new ExternalLogin\n320                  {\n321                      Provider = account.Provider,\n322                      ProviderDisplayName = clientData.DisplayName,\n323                      ProviderUserId = account.ProviderUserId,\n324                  });\n325              }\n326  \n327              ViewBag.ShowRemoveButton = externalLogins.Count > 1 || OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n328              return PartialView(\"_RemoveExternalLoginsPartial\", externalLogins);\n329          }\n330  \n331          #region Helpers\n332          private ActionResult RedirectToLocal(string returnUrl)\n333          {\n334              if (Url.IsLocalUrl(returnUrl))\n335              {\n336                  return Redirect(returnUrl);\n337              }"
         lineNumber: 326
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
@@ -891,6 +2814,7 @@
           fqdn_namespace: WebMatrix.WebData
           symbol: WebSecurity.GetUserId
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
         message: |
           WebMatrix.WebData.WebSecurity is not available in .NET Core and must be replaced with ASP.NET Core Identity.
@@ -904,7 +2828,7 @@
           - Replace WebSecurity.CreateUserAndAccount with UserManager.CreateAsync
           - Replace WebSecurity.ChangePassword with UserManager.ChangePasswordAsync
           - Configure Identity in Startup.ConfigureServices with AddIdentity or AddDefaultIdentity
-        codeSnip: "30                 {\n31                     using (var context = new UsersContext())\n32                     {\n33                         if (!context.Database.Exists())\n34                         {\n35                             // Create the SimpleMembership database without Entity Framework migration schema\n36                             ((IObjectContextAdapter)context).ObjectContext.CreateDatabase();\n37                         }\n38                     }\n39 \n40                     WebSecurity.InitializeDatabaseConnection(\"DefaultConnection\", \"UserProfile\", \"UserId\", \"UserName\", autoCreateTables: true);\n41                 }\n42                 catch (Exception ex)\n43                 {\n44                     throw new InvalidOperationException(\"The ASP.NET Simple Membership database could not be initialized. For more information, please see http://go.microsoft.com/fwlink/?LinkId=256588\", ex);\n45                 }\n46             }\n47         }\n48     }\n49 }\n"
+        codeSnip: " 31                  {\n 32                      using (var context = new UsersContext())\n 33                      {\n 34                          if (!context.Database.Exists())\n 35                          {\n 36                              // Create the SimpleMembership database without Entity Framework migration schema\n 37                              ((IObjectContextAdapter)context).ObjectContext.CreateDatabase();\n 38                          }\n 39                      }\n 40  \n 41                      WebSecurity.InitializeDatabaseConnection(\"DefaultConnection\", \"UserProfile\", \"UserId\", \"UserName\", autoCreateTables: true);\n 42                  }\n 43                  catch (Exception ex)\n 44                  {\n 45                      throw new InvalidOperationException(\"The ASP.NET Simple Membership database could not be initialized. For more information, please see http://go.microsoft.com/fwlink/?LinkId=256588\", ex);\n 46                  }\n 47              }\n 48          }\n 49      }\n 50  }"
         lineNumber: 40
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
@@ -913,6 +2837,7 @@
           fqdn_namespace: WebMatrix.WebData
           symbol: WebSecurity.InitializeDatabaseConnection
           syntax_type: method_reference
+        isDependencyIncident: false
       links:
       - url: https://learn.microsoft.com/en-us/aspnet/core/security/authentication/identity
         title: Introduction to Identity on ASP.NET Core
@@ -937,12 +2862,53 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "0 \uFEFFusing System.Web;\n1 using System.Web.Mvc;\n2 \n3 namespace NerdDinner\n4 {\n5     public class FilterConfig\n6     {\n7         public static void RegisterGlobalFilters(GlobalFilterCollection filters)\n8         {\n9             filters.Add(new HandleErrorAttribute());\n10         }\n11     }\n"
+        codeSnip: "  1  using System.Web;\n  2  using System.Web.Mvc;\n  3  \n  4  namespace NerdDinner\n  5  {\n  6      public class FilterConfig\n  7      {\n  8          public static void RegisterGlobalFilters(GlobalFilterCollection filters)\n  9          {\n 10              filters.Add(new HandleErrorAttribute());\n 11          }\n 12      }"
         lineNumber: 1
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/FilterConfig.cs
+          fqdn_namespace: System.Web.Mvc
           symbol: System.Web.Mvc
           syntax_type: import
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/FilterConfig.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: "  1  using System.Web;\n  2  using System.Web.Mvc;\n  3  \n  4  namespace NerdDinner\n  5  {\n  6      public class FilterConfig\n  7      {\n  8          public static void RegisterGlobalFilters(GlobalFilterCollection filters)\n  9          {\n 10              filters.Add(new HandleErrorAttribute());\n 11          }\n 12      }\n 13  }"
+        lineNumber: 7
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/FilterConfig.cs
+          fqdn_class: GlobalFilterCollection
+          fqdn_namespace: System.Web.Mvc
+          symbol: GlobalFilterCollection
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/FilterConfig.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: "  1  using System.Web;\n  2  using System.Web.Mvc;\n  3  \n  4  namespace NerdDinner\n  5  {\n  6      public class FilterConfig\n  7      {\n  8          public static void RegisterGlobalFilters(GlobalFilterCollection filters)\n  9          {\n 10              filters.Add(new HandleErrorAttribute());\n 11          }\n 12      }\n 13  }"
+        lineNumber: 9
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/FilterConfig.cs
+          fqdn_class: GlobalFilterCollection
+          fqdn_method: Add
+          fqdn_namespace: System.Web.Mvc
+          symbol: filters.Add
+          syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/RouteConfig.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -953,12 +2919,14 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "0 \uFEFFusing System;\n1 using System.Collections.Generic;\n2 using System.Linq;\n3 using System.Web;\n4 using System.Web.Mvc;\n5 using System.Web.Routing;\n6 \n7 namespace NerdDinner\n8 {\n9     public class RouteConfig\n10     {\n11         public static void RegisterRoutes(RouteCollection routes)\n12         {\n13             routes.IgnoreRoute(\"{resource}.axd/{*pathInfo}\");\n14 \n"
+        codeSnip: "  1  using System;\n  2  using System.Collections.Generic;\n  3  using System.Linq;\n  4  using System.Web;\n  5  using System.Web.Mvc;\n  6  using System.Web.Routing;\n  7  \n  8  namespace NerdDinner\n  9  {\n 10      public class RouteConfig\n 11      {\n 12          public static void RegisterRoutes(RouteCollection routes)\n 13          {\n 14              routes.IgnoreRoute(\"{resource}.axd/{*pathInfo}\");\n 15  "
         lineNumber: 4
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/RouteConfig.cs
+          fqdn_namespace: System.Web.Mvc
           symbol: System.Web.Mvc
           syntax_type: import
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/RouteConfig.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -969,7 +2937,67 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "15             routes.MapRoute(\n16                     \"PrettyDetails\",\n17                     \"{Id}\",\n18                         new { controller = \"Dinners\", action = \"Details\" },\n19                         new { Id = @\"\\d+\" }\n20                     );\n21 \n22             routes.MapRoute(\n23                 name: \"Default\",\n24                 url: \"{controller}/{action}/{id}\",\n25                 defaults: new { controller = \"Home\", action = \"Index\", id = UrlParameter.Optional }\n26             );\n27         }\n28     }\n29 }\n"
+        codeSnip: "  4  using System.Web;\n  5  using System.Web.Mvc;\n  6  using System.Web.Routing;\n  7  \n  8  namespace NerdDinner\n  9  {\n 10      public class RouteConfig\n 11      {\n 12          public static void RegisterRoutes(RouteCollection routes)\n 13          {\n 14              routes.IgnoreRoute(\"{resource}.axd/{*pathInfo}\");\n 15  \n 16              routes.MapRoute(\n 17                      \"PrettyDetails\",\n 18                      \"{Id}\",\n 19                          new { controller = \"Dinners\", action = \"Details\" },\n 20                          new { Id = @\"\\d+\" }\n 21                      );\n 22  \n 23              routes.MapRoute(\n 24                  name: \"Default\","
+        lineNumber: 13
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/RouteConfig.cs
+          fqdn_class: RouteCollectionExtensions
+          fqdn_method: IgnoreRoute
+          fqdn_namespace: System.Web.Mvc
+          symbol: routes.IgnoreRoute
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/RouteConfig.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: "  6  using System.Web.Routing;\n  7  \n  8  namespace NerdDinner\n  9  {\n 10      public class RouteConfig\n 11      {\n 12          public static void RegisterRoutes(RouteCollection routes)\n 13          {\n 14              routes.IgnoreRoute(\"{resource}.axd/{*pathInfo}\");\n 15  \n 16              routes.MapRoute(\n 17                      \"PrettyDetails\",\n 18                      \"{Id}\",\n 19                          new { controller = \"Dinners\", action = \"Details\" },\n 20                          new { Id = @\"\\d+\" }\n 21                      );\n 22  \n 23              routes.MapRoute(\n 24                  name: \"Default\",\n 25                  url: \"{controller}/{action}/{id}\",\n 26                  defaults: new { controller = \"Home\", action = \"Index\", id = UrlParameter.Optional }"
+        lineNumber: 15
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/RouteConfig.cs
+          fqdn_class: RouteCollectionExtensions
+          fqdn_method: MapRoute
+          fqdn_namespace: System.Web.Mvc
+          symbol: routes.MapRoute
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/RouteConfig.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 13          {\n 14              routes.IgnoreRoute(\"{resource}.axd/{*pathInfo}\");\n 15  \n 16              routes.MapRoute(\n 17                      \"PrettyDetails\",\n 18                      \"{Id}\",\n 19                          new { controller = \"Dinners\", action = \"Details\" },\n 20                          new { Id = @\"\\d+\" }\n 21                      );\n 22  \n 23              routes.MapRoute(\n 24                  name: \"Default\",\n 25                  url: \"{controller}/{action}/{id}\",\n 26                  defaults: new { controller = \"Home\", action = \"Index\", id = UrlParameter.Optional }\n 27              );\n 28          }\n 29      }\n 30  }"
+        lineNumber: 22
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/RouteConfig.cs
+          fqdn_class: RouteCollectionExtensions
+          fqdn_method: MapRoute
+          fqdn_namespace: System.Web.Mvc
+          symbol: routes.MapRoute
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/RouteConfig.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 16              routes.MapRoute(\n 17                      \"PrettyDetails\",\n 18                      \"{Id}\",\n 19                          new { controller = \"Dinners\", action = \"Details\" },\n 20                          new { Id = @\"\\d+\" }\n 21                      );\n 22  \n 23              routes.MapRoute(\n 24                  name: \"Default\",\n 25                  url: \"{controller}/{action}/{id}\",\n 26                  defaults: new { controller = \"Home\", action = \"Index\", id = UrlParameter.Optional }\n 27              );\n 28          }\n 29      }\n 30  }"
         lineNumber: 25
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/App_Start/RouteConfig.cs
@@ -978,6 +3006,7 @@
           fqdn_namespace: System.Web.Mvc
           symbol: UrlParameter.Optional
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -988,11 +3017,14 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: "  1  using System;\n  2  using System.Collections.Generic;\n  3  using System.Linq;\n  4  using System.Transactions;\n  5  using System.Web;\n  6  using System.Web.Mvc;\n  7  using System.Web.Security;\n  8  using DotNetOpenAuth.AspNet;\n  9  using Microsoft.Web.WebPages.OAuth;\n 10  using WebMatrix.WebData;\n 11  using NerdDinner.Filters;\n 12  using NerdDinner.Models;\n 13  \n 14  namespace NerdDinner.Controllers\n 15  {\n 16      [Authorize]"
         lineNumber: 5
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_namespace: System.Web.Mvc
           symbol: System.Web.Mvc
           syntax_type: import
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1003,14 +3035,92 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: "  6  using System.Web.Mvc;\n  7  using System.Web.Security;\n  8  using DotNetOpenAuth.AspNet;\n  9  using Microsoft.Web.WebPages.OAuth;\n 10  using WebMatrix.WebData;\n 11  using NerdDinner.Filters;\n 12  using NerdDinner.Models;\n 13  \n 14  namespace NerdDinner.Controllers\n 15  {\n 16      [Authorize]\n 17      [InitializeSimpleMembership]\n 18      public class AccountController : Controller\n 19      {\n 20          //\n 21          // GET: /Account/Login\n 22  \n 23          [AllowAnonymous]\n 24          public ActionResult Login(string returnUrl)\n 25          {\n 26              ViewBag.ReturnUrl = returnUrl;"
+        lineNumber: 15
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: AuthorizeAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: AuthorizeAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: "  8  using DotNetOpenAuth.AspNet;\n  9  using Microsoft.Web.WebPages.OAuth;\n 10  using WebMatrix.WebData;\n 11  using NerdDinner.Filters;\n 12  using NerdDinner.Models;\n 13  \n 14  namespace NerdDinner.Controllers\n 15  {\n 16      [Authorize]\n 17      [InitializeSimpleMembership]\n 18      public class AccountController : Controller\n 19      {\n 20          //\n 21          // GET: /Account/Login\n 22  \n 23          [AllowAnonymous]\n 24          public ActionResult Login(string returnUrl)\n 25          {\n 26              ViewBag.ReturnUrl = returnUrl;\n 27              return View();\n 28          }"
+        lineNumber: 17
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: Controller
+          fqdn_namespace: System.Web.Mvc
+          symbol: Controller
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 13  \n 14  namespace NerdDinner.Controllers\n 15  {\n 16      [Authorize]\n 17      [InitializeSimpleMembership]\n 18      public class AccountController : Controller\n 19      {\n 20          //\n 21          // GET: /Account/Login\n 22  \n 23          [AllowAnonymous]\n 24          public ActionResult Login(string returnUrl)\n 25          {\n 26              ViewBag.ReturnUrl = returnUrl;\n 27              return View();\n 28          }\n 29  \n 30          //\n 31          // POST: /Account/Login\n 32  \n 33          [HttpPost]"
+        lineNumber: 22
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: AllowAnonymousAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: AllowAnonymousAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 14  namespace NerdDinner.Controllers\n 15  {\n 16      [Authorize]\n 17      [InitializeSimpleMembership]\n 18      public class AccountController : Controller\n 19      {\n 20          //\n 21          // GET: /Account/Login\n 22  \n 23          [AllowAnonymous]\n 24          public ActionResult Login(string returnUrl)\n 25          {\n 26              ViewBag.ReturnUrl = returnUrl;\n 27              return View();\n 28          }\n 29  \n 30          //\n 31          // POST: /Account/Login\n 32  \n 33          [HttpPost]\n 34          [AllowAnonymous]"
+        lineNumber: 23
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 16      [Authorize]\n 17      [InitializeSimpleMembership]\n 18      public class AccountController : Controller\n 19      {\n 20          //\n 21          // GET: /Account/Login\n 22  \n 23          [AllowAnonymous]\n 24          public ActionResult Login(string returnUrl)\n 25          {\n 26              ViewBag.ReturnUrl = returnUrl;\n 27              return View();\n 28          }\n 29  \n 30          //\n 31          // POST: /Account/Login\n 32  \n 33          [HttpPost]\n 34          [AllowAnonymous]\n 35          [ValidateAntiForgeryToken]\n 36          public ActionResult Login(LoginModel model, string returnUrl)"
         lineNumber: 25
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: AjaxHelper
+          fqdn_class: ControllerBase
           fqdn_field: ViewBag
           fqdn_namespace: System.Web.Mvc
           symbol: ViewBag.ReturnUrl
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1021,14 +3131,111 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 17      [InitializeSimpleMembership]\n 18      public class AccountController : Controller\n 19      {\n 20          //\n 21          // GET: /Account/Login\n 22  \n 23          [AllowAnonymous]\n 24          public ActionResult Login(string returnUrl)\n 25          {\n 26              ViewBag.ReturnUrl = returnUrl;\n 27              return View();\n 28          }\n 29  \n 30          //\n 31          // POST: /Account/Login\n 32  \n 33          [HttpPost]\n 34          [AllowAnonymous]\n 35          [ValidateAntiForgeryToken]\n 36          public ActionResult Login(LoginModel model, string returnUrl)\n 37          {"
+        lineNumber: 26
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View()
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 23          [AllowAnonymous]\n 24          public ActionResult Login(string returnUrl)\n 25          {\n 26              ViewBag.ReturnUrl = returnUrl;\n 27              return View();\n 28          }\n 29  \n 30          //\n 31          // POST: /Account/Login\n 32  \n 33          [HttpPost]\n 34          [AllowAnonymous]\n 35          [ValidateAntiForgeryToken]\n 36          public ActionResult Login(LoginModel model, string returnUrl)\n 37          {\n 38              if (ModelState.IsValid && WebSecurity.Login(model.UserName, model.Password, persistCookie: model.RememberMe))\n 39              {\n 40                  return RedirectToLocal(returnUrl);\n 41              }\n 42  \n 43              // If we got this far, something failed, redisplay form"
+        lineNumber: 32
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: HttpPostAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: HttpPostAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 24          public ActionResult Login(string returnUrl)\n 25          {\n 26              ViewBag.ReturnUrl = returnUrl;\n 27              return View();\n 28          }\n 29  \n 30          //\n 31          // POST: /Account/Login\n 32  \n 33          [HttpPost]\n 34          [AllowAnonymous]\n 35          [ValidateAntiForgeryToken]\n 36          public ActionResult Login(LoginModel model, string returnUrl)\n 37          {\n 38              if (ModelState.IsValid && WebSecurity.Login(model.UserName, model.Password, persistCookie: model.RememberMe))\n 39              {\n 40                  return RedirectToLocal(returnUrl);\n 41              }\n 42  \n 43              // If we got this far, something failed, redisplay form\n 44              ModelState.AddModelError(\"\", \"The user name or password provided is incorrect.\");"
+        lineNumber: 33
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: AllowAnonymousAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: AllowAnonymousAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 25          {\n 26              ViewBag.ReturnUrl = returnUrl;\n 27              return View();\n 28          }\n 29  \n 30          //\n 31          // POST: /Account/Login\n 32  \n 33          [HttpPost]\n 34          [AllowAnonymous]\n 35          [ValidateAntiForgeryToken]\n 36          public ActionResult Login(LoginModel model, string returnUrl)\n 37          {\n 38              if (ModelState.IsValid && WebSecurity.Login(model.UserName, model.Password, persistCookie: model.RememberMe))\n 39              {\n 40                  return RedirectToLocal(returnUrl);\n 41              }\n 42  \n 43              // If we got this far, something failed, redisplay form\n 44              ModelState.AddModelError(\"\", \"The user name or password provided is incorrect.\");\n 45              return View(model);"
+        lineNumber: 34
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ValidateAntiForgeryTokenAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ValidateAntiForgeryTokenAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 26              ViewBag.ReturnUrl = returnUrl;\n 27              return View();\n 28          }\n 29  \n 30          //\n 31          // POST: /Account/Login\n 32  \n 33          [HttpPost]\n 34          [AllowAnonymous]\n 35          [ValidateAntiForgeryToken]\n 36          public ActionResult Login(LoginModel model, string returnUrl)\n 37          {\n 38              if (ModelState.IsValid && WebSecurity.Login(model.UserName, model.Password, persistCookie: model.RememberMe))\n 39              {\n 40                  return RedirectToLocal(returnUrl);\n 41              }\n 42  \n 43              // If we got this far, something failed, redisplay form\n 44              ModelState.AddModelError(\"\", \"The user name or password provided is incorrect.\");\n 45              return View(model);\n 46          }"
+        lineNumber: 35
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 28          }\n 29  \n 30          //\n 31          // POST: /Account/Login\n 32  \n 33          [HttpPost]\n 34          [AllowAnonymous]\n 35          [ValidateAntiForgeryToken]\n 36          public ActionResult Login(LoginModel model, string returnUrl)\n 37          {\n 38              if (ModelState.IsValid && WebSecurity.Login(model.UserName, model.Password, persistCookie: model.RememberMe))\n 39              {\n 40                  return RedirectToLocal(returnUrl);\n 41              }\n 42  \n 43              // If we got this far, something failed, redisplay form\n 44              ModelState.AddModelError(\"\", \"The user name or password provided is incorrect.\");\n 45              return View(model);\n 46          }\n 47  \n 48          //"
         lineNumber: 37
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: Controller
-          fqdn_field: ModelState
+          fqdn_class: ModelStateDictionary
+          fqdn_field: IsValid
           fqdn_namespace: System.Web.Mvc
           symbol: ModelState.IsValid
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1039,14 +3246,252 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 30          //\n 31          // POST: /Account/Login\n 32  \n 33          [HttpPost]\n 34          [AllowAnonymous]\n 35          [ValidateAntiForgeryToken]\n 36          public ActionResult Login(LoginModel model, string returnUrl)\n 37          {\n 38              if (ModelState.IsValid && WebSecurity.Login(model.UserName, model.Password, persistCookie: model.RememberMe))\n 39              {\n 40                  return RedirectToLocal(returnUrl);\n 41              }\n 42  \n 43              // If we got this far, something failed, redisplay form\n 44              ModelState.AddModelError(\"\", \"The user name or password provided is incorrect.\");\n 45              return View(model);\n 46          }\n 47  \n 48          //\n 49          // POST: /Account/LogOff\n 50  "
+        lineNumber: 39
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: RedirectToLocal(returnUrl)
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 34          [AllowAnonymous]\n 35          [ValidateAntiForgeryToken]\n 36          public ActionResult Login(LoginModel model, string returnUrl)\n 37          {\n 38              if (ModelState.IsValid && WebSecurity.Login(model.UserName, model.Password, persistCookie: model.RememberMe))\n 39              {\n 40                  return RedirectToLocal(returnUrl);\n 41              }\n 42  \n 43              // If we got this far, something failed, redisplay form\n 44              ModelState.AddModelError(\"\", \"The user name or password provided is incorrect.\");\n 45              return View(model);\n 46          }\n 47  \n 48          //\n 49          // POST: /Account/LogOff\n 50  \n 51          [HttpPost]\n 52          [ValidateAntiForgeryToken]\n 53          public ActionResult LogOff()\n 54          {"
         lineNumber: 43
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: Controller
-          fqdn_field: ModelState
+          fqdn_class: ModelStateDictionary
+          fqdn_method: AddModelError
           fqdn_namespace: System.Web.Mvc
           symbol: ModelState.AddModelError
-          syntax_type: field_reference
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 35          [ValidateAntiForgeryToken]\n 36          public ActionResult Login(LoginModel model, string returnUrl)\n 37          {\n 38              if (ModelState.IsValid && WebSecurity.Login(model.UserName, model.Password, persistCookie: model.RememberMe))\n 39              {\n 40                  return RedirectToLocal(returnUrl);\n 41              }\n 42  \n 43              // If we got this far, something failed, redisplay form\n 44              ModelState.AddModelError(\"\", \"The user name or password provided is incorrect.\");\n 45              return View(model);\n 46          }\n 47  \n 48          //\n 49          // POST: /Account/LogOff\n 50  \n 51          [HttpPost]\n 52          [ValidateAntiForgeryToken]\n 53          public ActionResult LogOff()\n 54          {\n 55              WebSecurity.Logout();"
+        lineNumber: 44
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View(model)
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 50
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: HttpPostAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: HttpPostAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 51
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ValidateAntiForgeryTokenAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ValidateAntiForgeryTokenAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 52
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 56
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: RedirectToRouteResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: RedirectToAction("Index", "Home")
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 62
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: AllowAnonymousAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: AllowAnonymousAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 63
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 65
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View()
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 71
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: HttpPostAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: HttpPostAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 72
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: AllowAnonymousAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: AllowAnonymousAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 73
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ValidateAntiForgeryTokenAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ValidateAntiForgeryTokenAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 74
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1060,11 +3505,30 @@
         lineNumber: 76
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: Controller
-          fqdn_field: ModelState
+          fqdn_class: ModelStateDictionary
+          fqdn_field: IsValid
           fqdn_namespace: System.Web.Mvc
           symbol: ModelState.IsValid
           syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 83
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: RedirectToRouteResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: RedirectToAction("Index", "Home")
+          syntax_type: type_usage
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1078,11 +3542,12 @@
         lineNumber: 87
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: Controller
-          fqdn_field: ModelState
+          fqdn_class: ModelStateDictionary
+          fqdn_method: AddModelError
           fqdn_namespace: System.Web.Mvc
           symbol: ModelState.AddModelError
-          syntax_type: field_reference
+          syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1093,15 +3558,87 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "96         // POST: /Account/Disassociate\n97 \n98         [HttpPost]\n99         [ValidateAntiForgeryToken]\n100         public ActionResult Disassociate(string provider, string providerUserId)\n101         {\n102             string ownerAccount = OAuthWebSecurity.GetUserName(provider, providerUserId);\n103             ManageMessageId? message = null;\n104 \n105             // Only disassociate the account if the currently logged in user is the owner\n106             if (ownerAccount == User.Identity.Name)\n107             {\n108                 // Use a transaction to prevent the user from deleting their last login credential\n109                 using (var scope = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions { IsolationLevel = IsolationLevel.Serializable }))\n110                 {\n111                     bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n112                     if (hasLocalAccount || OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name).Count > 1)\n113                     {\n114                         OAuthWebSecurity.DeleteAccount(provider, providerUserId);\n115                         scope.Complete();\n116                         message = ManageMessageId.RemoveLoginSuccess;\n"
+        lineNumber: 92
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View(model)
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 98
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: HttpPostAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: HttpPostAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 99
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ValidateAntiForgeryTokenAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ValidateAntiForgeryTokenAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 100
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
         lineNumber: 106
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1112,15 +3649,15 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "101         {\n102             string ownerAccount = OAuthWebSecurity.GetUserName(provider, providerUserId);\n103             ManageMessageId? message = null;\n104 \n105             // Only disassociate the account if the currently logged in user is the owner\n106             if (ownerAccount == User.Identity.Name)\n107             {\n108                 // Use a transaction to prevent the user from deleting their last login credential\n109                 using (var scope = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions { IsolationLevel = IsolationLevel.Serializable }))\n110                 {\n111                     bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n112                     if (hasLocalAccount || OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name).Count > 1)\n113                     {\n114                         OAuthWebSecurity.DeleteAccount(provider, providerUserId);\n115                         scope.Complete();\n116                         message = ManageMessageId.RemoveLoginSuccess;\n117                     }\n118                 }\n119             }\n120 \n121             return RedirectToAction(\"Manage\", new { Message = message });\n"
         lineNumber: 111
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1131,15 +3668,15 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "102             string ownerAccount = OAuthWebSecurity.GetUserName(provider, providerUserId);\n103             ManageMessageId? message = null;\n104 \n105             // Only disassociate the account if the currently logged in user is the owner\n106             if (ownerAccount == User.Identity.Name)\n107             {\n108                 // Use a transaction to prevent the user from deleting their last login credential\n109                 using (var scope = new TransactionScope(TransactionScopeOption.Required, new TransactionOptions { IsolationLevel = IsolationLevel.Serializable }))\n110                 {\n111                     bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n112                     if (hasLocalAccount || OAuthWebSecurity.GetAccountsFromUserName(User.Identity.Name).Count > 1)\n113                     {\n114                         OAuthWebSecurity.DeleteAccount(provider, providerUserId);\n115                         scope.Complete();\n116                         message = ManageMessageId.RemoveLoginSuccess;\n117                     }\n118                 }\n119             }\n120 \n121             return RedirectToAction(\"Manage\", new { Message = message });\n122         }\n"
         lineNumber: 112
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1150,15 +3687,51 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "119             }\n120 \n121             return RedirectToAction(\"Manage\", new { Message = message });\n122         }\n123 \n124         //\n125         // GET: /Account/Manage\n126 \n127         public ActionResult Manage(ManageMessageId? message)\n128         {\n129             ViewBag.StatusMessage =\n130                 message == ManageMessageId.ChangePasswordSuccess ? \"Your password has been changed.\"\n131                 : message == ManageMessageId.SetPasswordSuccess ? \"Your password has been set.\"\n132                 : message == ManageMessageId.RemoveLoginSuccess ? \"The external login was removed.\"\n133                 : \"\";\n134             ViewBag.HasLocalPassword = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n135             ViewBag.ReturnUrl = Url.Action(\"Manage\");\n136             return View();\n137         }\n138 \n139         //\n"
+        lineNumber: 121
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: RedirectToRouteResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: RedirectToAction("Manage", new { Message = message })
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 127
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
         lineNumber: 129
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: AjaxHelper
+          fqdn_class: ControllerBase
           fqdn_field: ViewBag
           fqdn_namespace: System.Web.Mvc
           symbol: ViewBag.StatusMessage
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1169,15 +3742,15 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "124         //\n125         // GET: /Account/Manage\n126 \n127         public ActionResult Manage(ManageMessageId? message)\n128         {\n129             ViewBag.StatusMessage =\n130                 message == ManageMessageId.ChangePasswordSuccess ? \"Your password has been changed.\"\n131                 : message == ManageMessageId.SetPasswordSuccess ? \"Your password has been set.\"\n132                 : message == ManageMessageId.RemoveLoginSuccess ? \"The external login was removed.\"\n133                 : \"\";\n134             ViewBag.HasLocalPassword = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n135             ViewBag.ReturnUrl = Url.Action(\"Manage\");\n136             return View();\n137         }\n138 \n139         //\n140         // POST: /Account/Manage\n141 \n142         [HttpPost]\n143         [ValidateAntiForgeryToken]\n144         public ActionResult Manage(LocalPasswordModel model)\n"
         lineNumber: 134
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: AjaxHelper
+          fqdn_class: ControllerBase
           fqdn_field: ViewBag
           fqdn_namespace: System.Web.Mvc
           symbol: ViewBag.HasLocalPassword
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1188,15 +3761,15 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "125         // GET: /Account/Manage\n126 \n127         public ActionResult Manage(ManageMessageId? message)\n128         {\n129             ViewBag.StatusMessage =\n130                 message == ManageMessageId.ChangePasswordSuccess ? \"Your password has been changed.\"\n131                 : message == ManageMessageId.SetPasswordSuccess ? \"Your password has been set.\"\n132                 : message == ManageMessageId.RemoveLoginSuccess ? \"The external login was removed.\"\n133                 : \"\";\n134             ViewBag.HasLocalPassword = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n135             ViewBag.ReturnUrl = Url.Action(\"Manage\");\n136             return View();\n137         }\n138 \n139         //\n140         // POST: /Account/Manage\n141 \n142         [HttpPost]\n143         [ValidateAntiForgeryToken]\n144         public ActionResult Manage(LocalPasswordModel model)\n145         {\n"
         lineNumber: 135
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: AjaxHelper
+          fqdn_class: ControllerBase
           fqdn_field: ViewBag
           fqdn_namespace: System.Web.Mvc
           symbol: ViewBag.ReturnUrl
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1207,15 +3780,87 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "136             return View();\n137         }\n138 \n139         //\n140         // POST: /Account/Manage\n141 \n142         [HttpPost]\n143         [ValidateAntiForgeryToken]\n144         public ActionResult Manage(LocalPasswordModel model)\n145         {\n146             bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n147             ViewBag.HasLocalPassword = hasLocalAccount;\n148             ViewBag.ReturnUrl = Url.Action(\"Manage\");\n149             if (hasLocalAccount)\n150             {\n151                 if (ModelState.IsValid)\n152                 {\n153                     // ChangePassword will throw an exception rather than return false in certain failure scenarios.\n154                     bool changePasswordSucceeded;\n155                     try\n156                     {\n"
+        lineNumber: 136
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View()
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 142
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: HttpPostAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: HttpPostAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 143
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ValidateAntiForgeryTokenAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ValidateAntiForgeryTokenAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 144
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
         lineNumber: 146
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1226,15 +3871,15 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "137         }\n138 \n139         //\n140         // POST: /Account/Manage\n141 \n142         [HttpPost]\n143         [ValidateAntiForgeryToken]\n144         public ActionResult Manage(LocalPasswordModel model)\n145         {\n146             bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n147             ViewBag.HasLocalPassword = hasLocalAccount;\n148             ViewBag.ReturnUrl = Url.Action(\"Manage\");\n149             if (hasLocalAccount)\n150             {\n151                 if (ModelState.IsValid)\n152                 {\n153                     // ChangePassword will throw an exception rather than return false in certain failure scenarios.\n154                     bool changePasswordSucceeded;\n155                     try\n156                     {\n157                         changePasswordSucceeded = WebSecurity.ChangePassword(User.Identity.Name, model.OldPassword, model.NewPassword);\n"
         lineNumber: 147
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: AjaxHelper
+          fqdn_class: ControllerBase
           fqdn_field: ViewBag
           fqdn_namespace: System.Web.Mvc
           symbol: ViewBag.HasLocalPassword
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1245,15 +3890,15 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "138 \n139         //\n140         // POST: /Account/Manage\n141 \n142         [HttpPost]\n143         [ValidateAntiForgeryToken]\n144         public ActionResult Manage(LocalPasswordModel model)\n145         {\n146             bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n147             ViewBag.HasLocalPassword = hasLocalAccount;\n148             ViewBag.ReturnUrl = Url.Action(\"Manage\");\n149             if (hasLocalAccount)\n150             {\n151                 if (ModelState.IsValid)\n152                 {\n153                     // ChangePassword will throw an exception rather than return false in certain failure scenarios.\n154                     bool changePasswordSucceeded;\n155                     try\n156                     {\n157                         changePasswordSucceeded = WebSecurity.ChangePassword(User.Identity.Name, model.OldPassword, model.NewPassword);\n158                     }\n"
         lineNumber: 148
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: AjaxHelper
+          fqdn_class: ControllerBase
           fqdn_field: ViewBag
           fqdn_namespace: System.Web.Mvc
           symbol: ViewBag.ReturnUrl
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1264,15 +3909,15 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "141 \n142         [HttpPost]\n143         [ValidateAntiForgeryToken]\n144         public ActionResult Manage(LocalPasswordModel model)\n145         {\n146             bool hasLocalAccount = OAuthWebSecurity.HasLocalAccount(WebSecurity.GetUserId(User.Identity.Name));\n147             ViewBag.HasLocalPassword = hasLocalAccount;\n148             ViewBag.ReturnUrl = Url.Action(\"Manage\");\n149             if (hasLocalAccount)\n150             {\n151                 if (ModelState.IsValid)\n152                 {\n153                     // ChangePassword will throw an exception rather than return false in certain failure scenarios.\n154                     bool changePasswordSucceeded;\n155                     try\n156                     {\n157                         changePasswordSucceeded = WebSecurity.ChangePassword(User.Identity.Name, model.OldPassword, model.NewPassword);\n158                     }\n159                     catch (Exception)\n160                     {\n161                         changePasswordSucceeded = false;\n"
         lineNumber: 151
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: Controller
-          fqdn_field: ModelState
+          fqdn_class: ModelStateDictionary
+          fqdn_field: IsValid
           fqdn_namespace: System.Web.Mvc
           symbol: ModelState.IsValid
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1283,15 +3928,15 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "147             ViewBag.HasLocalPassword = hasLocalAccount;\n148             ViewBag.ReturnUrl = Url.Action(\"Manage\");\n149             if (hasLocalAccount)\n150             {\n151                 if (ModelState.IsValid)\n152                 {\n153                     // ChangePassword will throw an exception rather than return false in certain failure scenarios.\n154                     bool changePasswordSucceeded;\n155                     try\n156                     {\n157                         changePasswordSucceeded = WebSecurity.ChangePassword(User.Identity.Name, model.OldPassword, model.NewPassword);\n158                     }\n159                     catch (Exception)\n160                     {\n161                         changePasswordSucceeded = false;\n162                     }\n163 \n164                     if (changePasswordSucceeded)\n165                     {\n166                         return RedirectToAction(\"Manage\", new { Message = ManageMessageId.ChangePasswordSuccess });\n167                     }\n"
         lineNumber: 157
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1302,15 +3947,33 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "160                     {\n161                         changePasswordSucceeded = false;\n162                     }\n163 \n164                     if (changePasswordSucceeded)\n165                     {\n166                         return RedirectToAction(\"Manage\", new { Message = ManageMessageId.ChangePasswordSuccess });\n167                     }\n168                     else\n169                     {\n170                         ModelState.AddModelError(\"\", \"The current password is incorrect or the new password is invalid.\");\n171                     }\n172                 }\n173             }\n174             else\n175             {\n176                 // User does not have a local password so remove any validation errors caused by a missing\n177                 // OldPassword field\n178                 ModelState state = ModelState[\"OldPassword\"];\n179                 if (state != null)\n180                 {\n"
+        lineNumber: 166
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: RedirectToRouteResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: RedirectToAction("Manage", new { Message = ManageMessageId.ChangePasswordSuccess })
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
         lineNumber: 170
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: Controller
-          fqdn_field: ModelState
+          fqdn_class: ModelStateDictionary
+          fqdn_method: AddModelError
           fqdn_namespace: System.Web.Mvc
           symbol: ModelState.AddModelError
-          syntax_type: field_reference
+          syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1321,15 +3984,14 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "171                     }\n172                 }\n173             }\n174             else\n175             {\n176                 // User does not have a local password so remove any validation errors caused by a missing\n177                 // OldPassword field\n178                 ModelState state = ModelState[\"OldPassword\"];\n179                 if (state != null)\n180                 {\n181                     state.Errors.Clear();\n182                 }\n183 \n184                 if (ModelState.IsValid)\n185                 {\n186                     try\n187                     {\n188                         WebSecurity.CreateAccount(User.Identity.Name, model.NewPassword);\n189                         return RedirectToAction(\"Manage\", new { Message = ManageMessageId.SetPasswordSuccess });\n190                     }\n191                     catch (Exception)\n"
-        lineNumber: 181
+        lineNumber: 178
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
           fqdn_class: ModelState
-          fqdn_field: Errors
           fqdn_namespace: System.Web.Mvc
-          symbol: state.Errors
-          syntax_type: field_reference
+          symbol: ModelState
+          syntax_type: type_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1340,15 +4002,34 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "174             else\n175             {\n176                 // User does not have a local password so remove any validation errors caused by a missing\n177                 // OldPassword field\n178                 ModelState state = ModelState[\"OldPassword\"];\n179                 if (state != null)\n180                 {\n181                     state.Errors.Clear();\n182                 }\n183 \n184                 if (ModelState.IsValid)\n185                 {\n186                     try\n187                     {\n188                         WebSecurity.CreateAccount(User.Identity.Name, model.NewPassword);\n189                         return RedirectToAction(\"Manage\", new { Message = ManageMessageId.SetPasswordSuccess });\n190                     }\n191                     catch (Exception)\n192                     {\n193                         ModelState.AddModelError(\"\", String.Format(\"Unable to create local account. An account with the name \\\"{0}\\\" may already exist.\", User.Identity.Name));\n194                     }\n"
+        lineNumber: 181
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: Collection
+          fqdn_method: Clear
+          fqdn_namespace: System.Collections.ObjectModel
+          symbol: Errors.Clear
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
         lineNumber: 184
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: Controller
-          fqdn_field: ModelState
+          fqdn_class: ModelStateDictionary
+          fqdn_field: IsValid
           fqdn_namespace: System.Web.Mvc
           symbol: ModelState.IsValid
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1359,15 +4040,15 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "178                 ModelState state = ModelState[\"OldPassword\"];\n179                 if (state != null)\n180                 {\n181                     state.Errors.Clear();\n182                 }\n183 \n184                 if (ModelState.IsValid)\n185                 {\n186                     try\n187                     {\n188                         WebSecurity.CreateAccount(User.Identity.Name, model.NewPassword);\n189                         return RedirectToAction(\"Manage\", new { Message = ManageMessageId.SetPasswordSuccess });\n190                     }\n191                     catch (Exception)\n192                     {\n193                         ModelState.AddModelError(\"\", String.Format(\"Unable to create local account. An account with the name \\\"{0}\\\" may already exist.\", User.Identity.Name));\n194                     }\n195                 }\n196             }\n197 \n198             // If we got this far, something failed, redisplay form\n"
         lineNumber: 188
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1378,15 +4059,33 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "183 \n184                 if (ModelState.IsValid)\n185                 {\n186                     try\n187                     {\n188                         WebSecurity.CreateAccount(User.Identity.Name, model.NewPassword);\n189                         return RedirectToAction(\"Manage\", new { Message = ManageMessageId.SetPasswordSuccess });\n190                     }\n191                     catch (Exception)\n192                     {\n193                         ModelState.AddModelError(\"\", String.Format(\"Unable to create local account. An account with the name \\\"{0}\\\" may already exist.\", User.Identity.Name));\n194                     }\n195                 }\n196             }\n197 \n198             // If we got this far, something failed, redisplay form\n199             return View(model);\n200         }\n201 \n202         //\n203         // POST: /Account/ExternalLogin\n"
+        lineNumber: 189
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: RedirectToRouteResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: RedirectToAction("Manage", new { Message = ManageMessageId.SetPasswordSuccess })
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
         lineNumber: 193
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: Controller
-          fqdn_field: ModelState
+          fqdn_class: ModelStateDictionary
+          fqdn_method: AddModelError
           fqdn_namespace: System.Web.Mvc
           symbol: ModelState.AddModelError
-          syntax_type: field_reference
+          syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1397,15 +4096,104 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "200         }\n201 \n202         //\n203         // POST: /Account/ExternalLogin\n204 \n205         [HttpPost]\n206         [AllowAnonymous]\n207         [ValidateAntiForgeryToken]\n208         public ActionResult ExternalLogin(string provider, string returnUrl)\n209         {\n210             return new ExternalLoginResult(provider, Url.Action(\"ExternalLoginCallback\", new { ReturnUrl = returnUrl }));\n211         }\n212 \n213         //\n214         // GET: /Account/ExternalLoginCallback\n215 \n216         [AllowAnonymous]\n217         public ActionResult ExternalLoginCallback(string returnUrl)\n218         {\n219             AuthenticationResult result = OAuthWebSecurity.VerifyAuthentication(Url.Action(\"ExternalLoginCallback\", new { ReturnUrl = returnUrl }));\n220             if (!result.IsSuccessful)\n"
+        lineNumber: 199
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View(model)
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 205
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: HttpPostAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: HttpPostAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 206
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: AllowAnonymousAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: AllowAnonymousAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 207
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ValidateAntiForgeryTokenAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ValidateAntiForgeryTokenAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 208
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
         lineNumber: 210
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: Controller
-          fqdn_field: Url
+          fqdn_class: ActionResult
           fqdn_namespace: System.Web.Mvc
-          symbol: Url.Action
-          syntax_type: field_reference
+          symbol: new ExternalLoginResult(provider, Url.Action("ExternalLoginCallback", new { ReturnUrl = returnUrl }))
+          syntax_type: type_usage
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1416,15 +4204,51 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "209         {\n210             return new ExternalLoginResult(provider, Url.Action(\"ExternalLoginCallback\", new { ReturnUrl = returnUrl }));\n211         }\n212 \n213         //\n214         // GET: /Account/ExternalLoginCallback\n215 \n216         [AllowAnonymous]\n217         public ActionResult ExternalLoginCallback(string returnUrl)\n218         {\n219             AuthenticationResult result = OAuthWebSecurity.VerifyAuthentication(Url.Action(\"ExternalLoginCallback\", new { ReturnUrl = returnUrl }));\n220             if (!result.IsSuccessful)\n221             {\n222                 return RedirectToAction(\"ExternalLoginFailure\");\n223             }\n224 \n225             if (OAuthWebSecurity.Login(result.Provider, result.ProviderUserId, createPersistentCookie: false))\n226             {\n227                 return RedirectToLocal(returnUrl);\n228             }\n229 \n"
+        lineNumber: 216
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: AllowAnonymousAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: AllowAnonymousAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 217
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
         lineNumber: 219
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: Controller
-          fqdn_field: Url
+          fqdn_class: UrlHelper
+          fqdn_method: Action
           fqdn_namespace: System.Web.Mvc
           symbol: Url.Action
-          syntax_type: field_reference
+          syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1435,15 +4259,51 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "220             if (!result.IsSuccessful)\n221             {\n222                 return RedirectToAction(\"ExternalLoginFailure\");\n223             }\n224 \n225             if (OAuthWebSecurity.Login(result.Provider, result.ProviderUserId, createPersistentCookie: false))\n226             {\n227                 return RedirectToLocal(returnUrl);\n228             }\n229 \n230             if (User.Identity.IsAuthenticated)\n231             {\n232                 // If the current user is logged in add the new account\n233                 OAuthWebSecurity.CreateOrUpdateAccount(result.Provider, result.ProviderUserId, User.Identity.Name);\n234                 return RedirectToLocal(returnUrl);\n235             }\n236             else\n237             {\n238                 // User is new, ask for their desired membership name\n239                 string loginData = OAuthWebSecurity.SerializeProviderUserId(result.Provider, result.ProviderUserId);\n240                 ViewBag.ProviderDisplayName = OAuthWebSecurity.GetOAuthClientData(result.Provider).DisplayName;\n"
+        lineNumber: 222
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: RedirectToRouteResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: RedirectToAction("ExternalLoginFailure")
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 227
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: RedirectToLocal(returnUrl)
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
         lineNumber: 230
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1454,15 +4314,33 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "223             }\n224 \n225             if (OAuthWebSecurity.Login(result.Provider, result.ProviderUserId, createPersistentCookie: false))\n226             {\n227                 return RedirectToLocal(returnUrl);\n228             }\n229 \n230             if (User.Identity.IsAuthenticated)\n231             {\n232                 // If the current user is logged in add the new account\n233                 OAuthWebSecurity.CreateOrUpdateAccount(result.Provider, result.ProviderUserId, User.Identity.Name);\n234                 return RedirectToLocal(returnUrl);\n235             }\n236             else\n237             {\n238                 // User is new, ask for their desired membership name\n239                 string loginData = OAuthWebSecurity.SerializeProviderUserId(result.Provider, result.ProviderUserId);\n240                 ViewBag.ProviderDisplayName = OAuthWebSecurity.GetOAuthClientData(result.Provider).DisplayName;\n241                 ViewBag.ReturnUrl = returnUrl;\n242                 return View(\"ExternalLoginConfirmation\", new RegisterExternalLoginModel { UserName = result.UserName, ExternalLoginData = loginData });\n243             }\n"
         lineNumber: 233
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 234
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: RedirectToLocal(returnUrl)
+          syntax_type: type_usage
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1476,11 +4354,12 @@
         lineNumber: 240
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: AjaxHelper
+          fqdn_class: ControllerBase
           fqdn_field: ViewBag
           fqdn_namespace: System.Web.Mvc
           symbol: ViewBag.ProviderDisplayName
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1494,11 +4373,102 @@
         lineNumber: 241
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: AjaxHelper
+          fqdn_class: ControllerBase
           fqdn_field: ViewBag
           fqdn_namespace: System.Web.Mvc
           symbol: ViewBag.ReturnUrl
           syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 242
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View("ExternalLoginConfirmation", new RegisterExternalLoginModel { UserName = result.UserName, ExternalLoginData = loginData })
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 249
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: HttpPostAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: HttpPostAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 250
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: AllowAnonymousAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: AllowAnonymousAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 251
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ValidateAntiForgeryTokenAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ValidateAntiForgeryTokenAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 252
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1515,8 +4485,27 @@
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 259
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: RedirectToRouteResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: RedirectToAction("Manage")
+          syntax_type: type_usage
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1530,11 +4519,30 @@
         lineNumber: 262
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: Controller
-          fqdn_field: ModelState
+          fqdn_class: ModelStateDictionary
+          fqdn_field: IsValid
           fqdn_namespace: System.Web.Mvc
           symbol: ModelState.IsValid
           syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 278
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: RedirectToLocal(returnUrl)
+          syntax_type: type_usage
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1548,11 +4556,12 @@
         lineNumber: 282
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: Controller
-          fqdn_field: ModelState
+          fqdn_class: ModelStateDictionary
+          fqdn_method: AddModelError
           fqdn_namespace: System.Web.Mvc
           symbol: ModelState.AddModelError
-          syntax_type: field_reference
+          syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1566,11 +4575,12 @@
         lineNumber: 287
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: AjaxHelper
+          fqdn_class: ControllerBase
           fqdn_field: ViewBag
           fqdn_namespace: System.Web.Mvc
           symbol: ViewBag.ProviderDisplayName
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1584,11 +4594,138 @@
         lineNumber: 288
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: AjaxHelper
+          fqdn_class: ControllerBase
           fqdn_field: ViewBag
           fqdn_namespace: System.Web.Mvc
           symbol: ViewBag.ReturnUrl
           syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 289
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View(model)
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 295
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: AllowAnonymousAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: AllowAnonymousAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 296
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 298
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View()
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 301
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: AllowAnonymousAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: AllowAnonymousAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 302
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ChildActionOnlyAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ChildActionOnlyAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 303
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1602,11 +4739,66 @@
         lineNumber: 305
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: AjaxHelper
+          fqdn_class: ControllerBase
           fqdn_field: ViewBag
           fqdn_namespace: System.Web.Mvc
           symbol: ViewBag.ReturnUrl
           syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 306
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: PartialViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: PartialView("_ExternalLoginsListPartial", OAuthWebSecurity.RegisteredClientData)
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 309
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ChildActionOnlyAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ChildActionOnlyAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 310
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1623,8 +4815,9 @@
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1638,11 +4831,48 @@
         lineNumber: 326
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: AjaxHelper
+          fqdn_class: ControllerBase
           fqdn_field: ViewBag
           fqdn_namespace: System.Web.Mvc
           symbol: ViewBag.ShowRemoveButton
           syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 327
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: PartialViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: PartialView("_RemoveExternalLoginsPartial", externalLogins)
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 331
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1656,11 +4886,84 @@
         lineNumber: 333
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
-          fqdn_class: Controller
-          fqdn_field: Url
+          fqdn_class: UrlHelper
+          fqdn_method: IsLocalUrl
           fqdn_namespace: System.Web.Mvc
           symbol: Url.IsLocalUrl
-          syntax_type: field_reference
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 335
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: RedirectResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: Redirect(returnUrl)
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 339
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: RedirectToRouteResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: RedirectToAction("Index", "Home")
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 350
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 361
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/AccountController.cs
+          fqdn_class: ControllerContext
+          fqdn_namespace: System.Web.Mvc
+          symbol: ControllerContext
+          syntax_type: type_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1671,12 +4974,14 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "0 \uFEFFusing System;\n1 using System.Collections.Generic;\n2 using System.Data;\n3 using System.Data.Entity;\n4 using System.Linq;\n5 using System.Web;\n6 using System.Web.Mvc;\n7 using NerdDinner.Models;\n8 using PagedList;\n9 \n10 namespace NerdDinner.Controllers\n11 {\n12     public class DinnersController : Controller\n13     {\n14         private NerdDinnerContext db = new NerdDinnerContext();\n15 \n16         //\n"
+        codeSnip: "  1  using System;\n  2  using System.Collections.Generic;\n  3  using System.Data;\n  4  using System.Data.Entity;\n  5  using System.Linq;\n  6  using System.Web;\n  7  using System.Web.Mvc;\n  8  using NerdDinner.Models;\n  9  using PagedList;\n 10  \n 11  namespace NerdDinner.Controllers\n 12  {\n 13      public class DinnersController : Controller\n 14      {\n 15          private NerdDinnerContext db = new NerdDinnerContext();\n 16  \n 17          //"
         lineNumber: 6
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_namespace: System.Web.Mvc
           symbol: System.Web.Mvc
           syntax_type: import
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1687,15 +4992,168 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "39 \n40         //\n41         // GET: /Dinners/Create\n42 \n43         [Authorize]\n44         public ActionResult Create()\n45         {\n46             var dinner = new Dinner()\n47             {\n48                 EventDate = DateTime.Now.AddDays(7),\n49                 HostedBy = User.Identity.Name\n50             };\n51 \n52             return View(dinner);\n53         }\n54 \n55         //\n56         // POST: /Dinners/Create\n57 \n58         [HttpPost, Authorize, ValidateAntiForgeryToken]\n59         public ActionResult Create(Dinner dinner)\n"
+        codeSnip: "  3  using System.Data;\n  4  using System.Data.Entity;\n  5  using System.Linq;\n  6  using System.Web;\n  7  using System.Web.Mvc;\n  8  using NerdDinner.Models;\n  9  using PagedList;\n 10  \n 11  namespace NerdDinner.Controllers\n 12  {\n 13      public class DinnersController : Controller\n 14      {\n 15          private NerdDinnerContext db = new NerdDinnerContext();\n 16  \n 17          //\n 18          // GET: /Dinners/\n 19          private const int PageSize = 25;\n 20          public ActionResult Index(int? page)\n 21          {\n 22              int pageIndex = page ?? 1;\n 23  "
+        lineNumber: 12
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: Controller
+          fqdn_namespace: System.Web.Mvc
+          symbol: Controller
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 10  \n 11  namespace NerdDinner.Controllers\n 12  {\n 13      public class DinnersController : Controller\n 14      {\n 15          private NerdDinnerContext db = new NerdDinnerContext();\n 16  \n 17          //\n 18          // GET: /Dinners/\n 19          private const int PageSize = 25;\n 20          public ActionResult Index(int? page)\n 21          {\n 22              int pageIndex = page ?? 1;\n 23  \n 24              var dinners = db.Dinners.Where(d => d.EventDate >= DateTime.Now).OrderBy(d => d.EventDate);\n 25              return View(dinners.ToPagedList(pageIndex, PageSize));\n 26          }\n 27  \n 28          //\n 29          // GET: /Dinners/Details/5\n 30  "
+        lineNumber: 19
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 15          private NerdDinnerContext db = new NerdDinnerContext();\n 16  \n 17          //\n 18          // GET: /Dinners/\n 19          private const int PageSize = 25;\n 20          public ActionResult Index(int? page)\n 21          {\n 22              int pageIndex = page ?? 1;\n 23  \n 24              var dinners = db.Dinners.Where(d => d.EventDate >= DateTime.Now).OrderBy(d => d.EventDate);\n 25              return View(dinners.ToPagedList(pageIndex, PageSize));\n 26          }\n 27  \n 28          //\n 29          // GET: /Dinners/Details/5\n 30  \n 31          public ActionResult Details(int id = 0)\n 32          {\n 33              Dinner dinner = db.Dinners.Find(id);\n 34              if (dinner == null)\n 35              {"
+        lineNumber: 24
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View(dinners.ToPagedList(pageIndex, PageSize))
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 21          {\n 22              int pageIndex = page ?? 1;\n 23  \n 24              var dinners = db.Dinners.Where(d => d.EventDate >= DateTime.Now).OrderBy(d => d.EventDate);\n 25              return View(dinners.ToPagedList(pageIndex, PageSize));\n 26          }\n 27  \n 28          //\n 29          // GET: /Dinners/Details/5\n 30  \n 31          public ActionResult Details(int id = 0)\n 32          {\n 33              Dinner dinner = db.Dinners.Find(id);\n 34              if (dinner == null)\n 35              {\n 36                  return HttpNotFound();\n 37              }\n 38              return View(dinner);\n 39          }\n 40  \n 41          //"
+        lineNumber: 30
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 26          }\n 27  \n 28          //\n 29          // GET: /Dinners/Details/5\n 30  \n 31          public ActionResult Details(int id = 0)\n 32          {\n 33              Dinner dinner = db.Dinners.Find(id);\n 34              if (dinner == null)\n 35              {\n 36                  return HttpNotFound();\n 37              }\n 38              return View(dinner);\n 39          }\n 40  \n 41          //\n 42          // GET: /Dinners/Create\n 43  \n 44          [Authorize]\n 45          public ActionResult Create()\n 46          {"
+        lineNumber: 35
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: HttpNotFoundResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: HttpNotFound()
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 28          //\n 29          // GET: /Dinners/Details/5\n 30  \n 31          public ActionResult Details(int id = 0)\n 32          {\n 33              Dinner dinner = db.Dinners.Find(id);\n 34              if (dinner == null)\n 35              {\n 36                  return HttpNotFound();\n 37              }\n 38              return View(dinner);\n 39          }\n 40  \n 41          //\n 42          // GET: /Dinners/Create\n 43  \n 44          [Authorize]\n 45          public ActionResult Create()\n 46          {\n 47              var dinner = new Dinner()\n 48              {"
+        lineNumber: 37
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View(dinner)
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 34              if (dinner == null)\n 35              {\n 36                  return HttpNotFound();\n 37              }\n 38              return View(dinner);\n 39          }\n 40  \n 41          //\n 42          // GET: /Dinners/Create\n 43  \n 44          [Authorize]\n 45          public ActionResult Create()\n 46          {\n 47              var dinner = new Dinner()\n 48              {\n 49                  EventDate = DateTime.Now.AddDays(7),\n 50                  HostedBy = User.Identity.Name\n 51              };\n 52  \n 53              return View(dinner);\n 54          }"
+        lineNumber: 43
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: AuthorizeAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: AuthorizeAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 35              {\n 36                  return HttpNotFound();\n 37              }\n 38              return View(dinner);\n 39          }\n 40  \n 41          //\n 42          // GET: /Dinners/Create\n 43  \n 44          [Authorize]\n 45          public ActionResult Create()\n 46          {\n 47              var dinner = new Dinner()\n 48              {\n 49                  EventDate = DateTime.Now.AddDays(7),\n 50                  HostedBy = User.Identity.Name\n 51              };\n 52  \n 53              return View(dinner);\n 54          }\n 55  "
+        lineNumber: 44
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 40  \n 41          //\n 42          // GET: /Dinners/Create\n 43  \n 44          [Authorize]\n 45          public ActionResult Create()\n 46          {\n 47              var dinner = new Dinner()\n 48              {\n 49                  EventDate = DateTime.Now.AddDays(7),\n 50                  HostedBy = User.Identity.Name\n 51              };\n 52  \n 53              return View(dinner);\n 54          }\n 55  \n 56          //\n 57          // POST: /Dinners/Create\n 58  \n 59          [HttpPost, Authorize, ValidateAntiForgeryToken]\n 60          public ActionResult Create(Dinner dinner)"
         lineNumber: 49
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1706,15 +5164,73 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "51 \n52             return View(dinner);\n53         }\n54 \n55         //\n56         // POST: /Dinners/Create\n57 \n58         [HttpPost, Authorize, ValidateAntiForgeryToken]\n59         public ActionResult Create(Dinner dinner)\n60         {\n61             if (ModelState.IsValid)\n62             {\n63                 dinner.HostedBy = User.Identity.Name;\n64 \n65                 RSVP rsvp = new RSVP();\n66                 rsvp.AttendeeName = User.Identity.Name;\n67 \n68                 dinner.RSVPs = new List<RSVP>();\n69                 dinner.RSVPs.Add(rsvp);\n70 \n71                 db.Dinners.Add(dinner);\n"
+        codeSnip: " 43  \n 44          [Authorize]\n 45          public ActionResult Create()\n 46          {\n 47              var dinner = new Dinner()\n 48              {\n 49                  EventDate = DateTime.Now.AddDays(7),\n 50                  HostedBy = User.Identity.Name\n 51              };\n 52  \n 53              return View(dinner);\n 54          }\n 55  \n 56          //\n 57          // POST: /Dinners/Create\n 58  \n 59          [HttpPost, Authorize, ValidateAntiForgeryToken]\n 60          public ActionResult Create(Dinner dinner)\n 61          {\n 62              if (ModelState.IsValid)\n 63              {"
+        lineNumber: 52
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View(dinner)
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 49                  EventDate = DateTime.Now.AddDays(7),\n 50                  HostedBy = User.Identity.Name\n 51              };\n 52  \n 53              return View(dinner);\n 54          }\n 55  \n 56          //\n 57          // POST: /Dinners/Create\n 58  \n 59          [HttpPost, Authorize, ValidateAntiForgeryToken]\n 60          public ActionResult Create(Dinner dinner)\n 61          {\n 62              if (ModelState.IsValid)\n 63              {\n 64                  dinner.HostedBy = User.Identity.Name;\n 65  \n 66                  RSVP rsvp = new RSVP();\n 67                  rsvp.AttendeeName = User.Identity.Name;\n 68  \n 69                  dinner.RSVPs = new List<RSVP>();"
+        lineNumber: 58
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: HttpPostAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: HttpPostAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 50                  HostedBy = User.Identity.Name\n 51              };\n 52  \n 53              return View(dinner);\n 54          }\n 55  \n 56          //\n 57          // POST: /Dinners/Create\n 58  \n 59          [HttpPost, Authorize, ValidateAntiForgeryToken]\n 60          public ActionResult Create(Dinner dinner)\n 61          {\n 62              if (ModelState.IsValid)\n 63              {\n 64                  dinner.HostedBy = User.Identity.Name;\n 65  \n 66                  RSVP rsvp = new RSVP();\n 67                  rsvp.AttendeeName = User.Identity.Name;\n 68  \n 69                  dinner.RSVPs = new List<RSVP>();\n 70                  dinner.RSVPs.Add(rsvp);"
+        lineNumber: 59
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 52  \n 53              return View(dinner);\n 54          }\n 55  \n 56          //\n 57          // POST: /Dinners/Create\n 58  \n 59          [HttpPost, Authorize, ValidateAntiForgeryToken]\n 60          public ActionResult Create(Dinner dinner)\n 61          {\n 62              if (ModelState.IsValid)\n 63              {\n 64                  dinner.HostedBy = User.Identity.Name;\n 65  \n 66                  RSVP rsvp = new RSVP();\n 67                  rsvp.AttendeeName = User.Identity.Name;\n 68  \n 69                  dinner.RSVPs = new List<RSVP>();\n 70                  dinner.RSVPs.Add(rsvp);\n 71  \n 72                  db.Dinners.Add(dinner);"
         lineNumber: 61
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
-          fqdn_class: Controller
-          fqdn_field: ModelState
+          fqdn_class: ModelStateDictionary
+          fqdn_field: IsValid
           fqdn_namespace: System.Web.Mvc
           symbol: ModelState.IsValid
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1725,15 +5241,15 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "53         }\n54 \n55         //\n56         // POST: /Dinners/Create\n57 \n58         [HttpPost, Authorize, ValidateAntiForgeryToken]\n59         public ActionResult Create(Dinner dinner)\n60         {\n61             if (ModelState.IsValid)\n62             {\n63                 dinner.HostedBy = User.Identity.Name;\n64 \n65                 RSVP rsvp = new RSVP();\n66                 rsvp.AttendeeName = User.Identity.Name;\n67 \n68                 dinner.RSVPs = new List<RSVP>();\n69                 dinner.RSVPs.Add(rsvp);\n70 \n71                 db.Dinners.Add(dinner);\n72                 db.SaveChanges();\n73                 return RedirectToAction(\"Index\");\n"
         lineNumber: 63
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1744,15 +5260,15 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "56         // POST: /Dinners/Create\n57 \n58         [HttpPost, Authorize, ValidateAntiForgeryToken]\n59         public ActionResult Create(Dinner dinner)\n60         {\n61             if (ModelState.IsValid)\n62             {\n63                 dinner.HostedBy = User.Identity.Name;\n64 \n65                 RSVP rsvp = new RSVP();\n66                 rsvp.AttendeeName = User.Identity.Name;\n67 \n68                 dinner.RSVPs = new List<RSVP>();\n69                 dinner.RSVPs.Add(rsvp);\n70 \n71                 db.Dinners.Add(dinner);\n72                 db.SaveChanges();\n73                 return RedirectToAction(\"Index\");\n74             }\n75 \n76             return View(dinner);\n"
         lineNumber: 66
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1763,15 +5279,105 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "80         // GET: /Dinners/Edit/5\n81 \n82         [Authorize]\n83         public ActionResult Edit(int id = 0)\n84         {\n85             Dinner dinner = db.Dinners.Find(id);\n86             if (dinner == null)\n87             {\n88                 return HttpNotFound();\n89             }\n90             if (!dinner.IsHostedBy(User.Identity.Name))\n91             {\n92                 return View(\"InvalidOwner\");\n93             }\n94             return View(dinner);\n95         }\n96 \n97         //\n98         // POST: /Dinners/Edit/5\n99 \n100         [HttpPost, Authorize, ValidateAntiForgeryToken]\n"
+        lineNumber: 73
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: RedirectToRouteResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: RedirectToAction("Index")
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 76
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View(dinner)
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 82
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: AuthorizeAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: AuthorizeAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 83
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 88
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: HttpNotFoundResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: HttpNotFound()
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
         lineNumber: 90
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1782,15 +5388,87 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "93             }\n94             return View(dinner);\n95         }\n96 \n97         //\n98         // POST: /Dinners/Edit/5\n99 \n100         [HttpPost, Authorize, ValidateAntiForgeryToken]\n101         public ActionResult Edit(Dinner dinner)\n102         {\n103             if (!dinner.IsHostedBy(User.Identity.Name))\n104             {\n105                 return View(\"InvalidOwner\");\n106             }\n107 \n108             if (ModelState.IsValid)\n109             {\n110                 db.Entry(dinner).State = EntityState.Modified;\n111                 db.SaveChanges();\n112                 return RedirectToAction(\"Index\");\n113             }\n"
+        lineNumber: 92
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View("InvalidOwner")
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 94
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View(dinner)
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 100
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: HttpPostAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: HttpPostAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 101
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
         lineNumber: 103
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1801,15 +5479,33 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "98         // POST: /Dinners/Edit/5\n99 \n100         [HttpPost, Authorize, ValidateAntiForgeryToken]\n101         public ActionResult Edit(Dinner dinner)\n102         {\n103             if (!dinner.IsHostedBy(User.Identity.Name))\n104             {\n105                 return View(\"InvalidOwner\");\n106             }\n107 \n108             if (ModelState.IsValid)\n109             {\n110                 db.Entry(dinner).State = EntityState.Modified;\n111                 db.SaveChanges();\n112                 return RedirectToAction(\"Index\");\n113             }\n114             return View(dinner);\n115         }\n116 \n117         //\n118         // GET: /Dinners/Delete/5\n"
+        lineNumber: 105
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View("InvalidOwner")
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
         lineNumber: 108
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
-          fqdn_class: Controller
-          fqdn_field: ModelState
+          fqdn_class: ModelStateDictionary
+          fqdn_field: IsValid
           fqdn_namespace: System.Web.Mvc
           symbol: ModelState.IsValid
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1820,15 +5516,105 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "118         // GET: /Dinners/Delete/5\n119 \n120         [Authorize]\n121         public ActionResult Delete(int id = 0)\n122         {\n123             Dinner dinner = db.Dinners.Find(id);\n124             if (dinner == null)\n125             {\n126                 return HttpNotFound();\n127             }\n128             if (!dinner.IsHostedBy(User.Identity.Name))\n129             {\n130                 return View(\"InvalidOwner\");\n131             }\n132             return View(dinner);\n133         }\n134 \n135         //\n136         // POST: /Dinners/Delete/5\n137 \n138         [HttpPost, ActionName(\"Delete\"), Authorize, ValidateAntiForgeryToken]\n"
+        lineNumber: 112
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: RedirectToRouteResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: RedirectToAction("Index")
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 114
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View(dinner)
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 120
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: AuthorizeAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: AuthorizeAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 121
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 126
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: HttpNotFoundResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: HttpNotFound()
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
         lineNumber: 128
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1839,15 +5625,252 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "133         }\n134 \n135         //\n136         // POST: /Dinners/Delete/5\n137 \n138         [HttpPost, ActionName(\"Delete\"), Authorize, ValidateAntiForgeryToken]\n139         public ActionResult DeleteConfirmed(int id)\n140         {\n141             Dinner dinner = db.Dinners.Find(id);\n142 \n143             if (!dinner.IsHostedBy(User.Identity.Name))\n144             {\n145                 return View(\"InvalidOwner\");\n146             }\n147 \n148             db.Dinners.Remove(dinner);\n149             db.SaveChanges();\n150             return RedirectToAction(\"Index\");\n151         }\n152 \n153         protected override void Dispose(bool disposing)\n"
+        lineNumber: 130
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View("InvalidOwner")
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 132
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View(dinner)
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 138
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: HttpPostAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: HttpPostAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 139
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
         lineNumber: 143
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 145
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View("InvalidOwner")
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 150
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: RedirectToRouteResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: RedirectToAction("Index")
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 156
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: Controller
+          fqdn_method: Dispose
+          fqdn_namespace: System.Web.Mvc
+          symbol: base.Dispose
+          syntax_type: method_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 159
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 161
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ControllerBase
+          fqdn_field: ViewData
+          fqdn_namespace: System.Web.Mvc
+          symbol: ViewData
+          syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 166
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View("WebSlice", model.Take(5))
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 169
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 171
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ControllerBase
+          fqdn_field: ViewData
+          fqdn_namespace: System.Web.Mvc
+          symbol: ViewData
+          syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        lineNumber: 177
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/DinnersController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View("WebSlice", model.Take(5))
+          syntax_type: type_usage
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/HomeController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1858,12 +5881,14 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "0 \uFEFFusing System;\n1 using System.Collections.Generic;\n2 using System.Linq;\n3 using System.Web;\n4 using System.Web.Mvc;\n5 \n6 namespace NerdDinner.Controllers\n7 {\n8     public class HomeController : Controller\n9     {\n10         public ActionResult Index()\n11         {\n12             ViewBag.Message = \"Organizing the world's nerds and helping them eat in packs.\";\n13 \n14             return View();\n"
+        codeSnip: "  1  using System;\n  2  using System.Collections.Generic;\n  3  using System.Linq;\n  4  using System.Web;\n  5  using System.Web.Mvc;\n  6  \n  7  namespace NerdDinner.Controllers\n  8  {\n  9      public class HomeController : Controller\n 10      {\n 11          public ActionResult Index()\n 12          {\n 13              ViewBag.Message = \"Organizing the world's nerds and helping them eat in packs.\";\n 14  \n 15              return View();"
         lineNumber: 4
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/HomeController.cs
+          fqdn_namespace: System.Web.Mvc
           symbol: System.Web.Mvc
           syntax_type: import
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/HomeController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1874,15 +5899,111 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "2 using System.Linq;\n3 using System.Web;\n4 using System.Web.Mvc;\n5 \n6 namespace NerdDinner.Controllers\n7 {\n8     public class HomeController : Controller\n9     {\n10         public ActionResult Index()\n11         {\n12             ViewBag.Message = \"Organizing the world's nerds and helping them eat in packs.\";\n13 \n14             return View();\n15         }\n16 \n17         public ActionResult About()\n18         {\n19             return View();\n20         }\n21 }\n22 }\n"
+        codeSnip: "  1  using System;\n  2  using System.Collections.Generic;\n  3  using System.Linq;\n  4  using System.Web;\n  5  using System.Web.Mvc;\n  6  \n  7  namespace NerdDinner.Controllers\n  8  {\n  9      public class HomeController : Controller\n 10      {\n 11          public ActionResult Index()\n 12          {\n 13              ViewBag.Message = \"Organizing the world's nerds and helping them eat in packs.\";\n 14  \n 15              return View();\n 16          }\n 17  \n 18          public ActionResult About()\n 19          {"
+        lineNumber: 8
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/HomeController.cs
+          fqdn_class: Controller
+          fqdn_namespace: System.Web.Mvc
+          symbol: Controller
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/HomeController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: "  1  using System;\n  2  using System.Collections.Generic;\n  3  using System.Linq;\n  4  using System.Web;\n  5  using System.Web.Mvc;\n  6  \n  7  namespace NerdDinner.Controllers\n  8  {\n  9      public class HomeController : Controller\n 10      {\n 11          public ActionResult Index()\n 12          {\n 13              ViewBag.Message = \"Organizing the world's nerds and helping them eat in packs.\";\n 14  \n 15              return View();\n 16          }\n 17  \n 18          public ActionResult About()\n 19          {\n 20              return View();\n 21          }"
+        lineNumber: 10
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/HomeController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/HomeController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: "  3  using System.Linq;\n  4  using System.Web;\n  5  using System.Web.Mvc;\n  6  \n  7  namespace NerdDinner.Controllers\n  8  {\n  9      public class HomeController : Controller\n 10      {\n 11          public ActionResult Index()\n 12          {\n 13              ViewBag.Message = \"Organizing the world's nerds and helping them eat in packs.\";\n 14  \n 15              return View();\n 16          }\n 17  \n 18          public ActionResult About()\n 19          {\n 20              return View();\n 21          }\n 22  }\n 23  }"
         lineNumber: 12
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/HomeController.cs
-          fqdn_class: AjaxHelper
+          fqdn_class: ControllerBase
           fqdn_field: ViewBag
           fqdn_namespace: System.Web.Mvc
           symbol: ViewBag.Message
           syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/HomeController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: "  5  using System.Web.Mvc;\n  6  \n  7  namespace NerdDinner.Controllers\n  8  {\n  9      public class HomeController : Controller\n 10      {\n 11          public ActionResult Index()\n 12          {\n 13              ViewBag.Message = \"Organizing the world's nerds and helping them eat in packs.\";\n 14  \n 15              return View();\n 16          }\n 17  \n 18          public ActionResult About()\n 19          {\n 20              return View();\n 21          }\n 22  }\n 23  }"
+        lineNumber: 14
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/HomeController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View()
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/HomeController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: "  8  {\n  9      public class HomeController : Controller\n 10      {\n 11          public ActionResult Index()\n 12          {\n 13              ViewBag.Message = \"Organizing the world's nerds and helping them eat in packs.\";\n 14  \n 15              return View();\n 16          }\n 17  \n 18          public ActionResult About()\n 19          {\n 20              return View();\n 21          }\n 22  }\n 23  }"
+        lineNumber: 17
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/HomeController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/HomeController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 10      {\n 11          public ActionResult Index()\n 12          {\n 13              ViewBag.Message = \"Organizing the world's nerds and helping them eat in packs.\";\n 14  \n 15              return View();\n 16          }\n 17  \n 18          public ActionResult About()\n 19          {\n 20              return View();\n 21          }\n 22  }\n 23  }"
+        lineNumber: 19
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/HomeController.cs
+          fqdn_class: ViewResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: View()
+          syntax_type: type_usage
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1893,12 +6014,14 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "0 \uFEFFusing System;\n1 using System.Globalization;\n2 using System.Linq;\n3 using System.Web.Mvc;\n4 using NerdDinner.Helpers;\n5 using NerdDinner.Models;\n6 \n7 namespace NerdDinner.Controllers\n8 {\n9     public class RSVPController : Controller\n10     {\n11         private NerdDinnerContext db = new NerdDinnerContext();\n12 \n13         //\n"
+        codeSnip: "  1  using System;\n  2  using System.Globalization;\n  3  using System.Linq;\n  4  using System.Web.Mvc;\n  5  using NerdDinner.Helpers;\n  6  using NerdDinner.Models;\n  7  \n  8  namespace NerdDinner.Controllers\n  9  {\n 10      public class RSVPController : Controller\n 11      {\n 12          private NerdDinnerContext db = new NerdDinnerContext();\n 13  \n 14          //"
         lineNumber: 3
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_namespace: System.Web.Mvc
           symbol: System.Web.Mvc
           syntax_type: import
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1909,15 +6032,149 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "25         public ActionResult RegisterAjax(int id)\n26         {\n27             RegisterForDinner(id);\n28             return Content(\"Thanks - we'll see you there!\");\n29         }\n30 \n31         private void RegisterForDinner(int id)\n32         {\n33             Dinner dinner = db.Dinners.Find(id);\n34 \n35             if (!dinner.IsUserRegistered(User.Identity.Name))\n36             {\n37                 RSVP rsvp = new RSVP();\n38                 rsvp.AttendeeName = User.Identity.Name;\n39 \n40                 dinner.RSVPs.Add(rsvp);\n41                 db.SaveChanges();\n42             }\n43         }\n44 \n45         //\n"
+        codeSnip: "  1  using System;\n  2  using System.Globalization;\n  3  using System.Linq;\n  4  using System.Web.Mvc;\n  5  using NerdDinner.Helpers;\n  6  using NerdDinner.Models;\n  7  \n  8  namespace NerdDinner.Controllers\n  9  {\n 10      public class RSVPController : Controller\n 11      {\n 12          private NerdDinnerContext db = new NerdDinnerContext();\n 13  \n 14          //\n 15          // HTTP: /RSVP/Register/1\n 16          [Authorize]\n 17          public ActionResult Register(int id)\n 18          {\n 19              RegisterForDinner(id);\n 20              return RedirectToAction(\"Details\", \"Dinners\", new { id = id });"
+        lineNumber: 9
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_class: Controller
+          fqdn_namespace: System.Web.Mvc
+          symbol: Controller
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: "  6  using NerdDinner.Models;\n  7  \n  8  namespace NerdDinner.Controllers\n  9  {\n 10      public class RSVPController : Controller\n 11      {\n 12          private NerdDinnerContext db = new NerdDinnerContext();\n 13  \n 14          //\n 15          // HTTP: /RSVP/Register/1\n 16          [Authorize]\n 17          public ActionResult Register(int id)\n 18          {\n 19              RegisterForDinner(id);\n 20              return RedirectToAction(\"Details\", \"Dinners\", new { id = id });\n 21          }\n 22  \n 23          //\n 24          // AJAX: /Dinners/RegisterAjax/1\n 25          [Authorize, HttpPost]\n 26          public ActionResult RegisterAjax(int id)"
+        lineNumber: 15
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_class: AuthorizeAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: AuthorizeAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: "  7  \n  8  namespace NerdDinner.Controllers\n  9  {\n 10      public class RSVPController : Controller\n 11      {\n 12          private NerdDinnerContext db = new NerdDinnerContext();\n 13  \n 14          //\n 15          // HTTP: /RSVP/Register/1\n 16          [Authorize]\n 17          public ActionResult Register(int id)\n 18          {\n 19              RegisterForDinner(id);\n 20              return RedirectToAction(\"Details\", \"Dinners\", new { id = id });\n 21          }\n 22  \n 23          //\n 24          // AJAX: /Dinners/RegisterAjax/1\n 25          [Authorize, HttpPost]\n 26          public ActionResult RegisterAjax(int id)\n 27          {"
+        lineNumber: 16
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 10      public class RSVPController : Controller\n 11      {\n 12          private NerdDinnerContext db = new NerdDinnerContext();\n 13  \n 14          //\n 15          // HTTP: /RSVP/Register/1\n 16          [Authorize]\n 17          public ActionResult Register(int id)\n 18          {\n 19              RegisterForDinner(id);\n 20              return RedirectToAction(\"Details\", \"Dinners\", new { id = id });\n 21          }\n 22  \n 23          //\n 24          // AJAX: /Dinners/RegisterAjax/1\n 25          [Authorize, HttpPost]\n 26          public ActionResult RegisterAjax(int id)\n 27          {\n 28              RegisterForDinner(id);\n 29              return Content(\"Thanks - we'll see you there!\");\n 30          }"
+        lineNumber: 19
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_class: RedirectToRouteResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: RedirectToAction("Details", "Dinners", new { id = id })
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 15          // HTTP: /RSVP/Register/1\n 16          [Authorize]\n 17          public ActionResult Register(int id)\n 18          {\n 19              RegisterForDinner(id);\n 20              return RedirectToAction(\"Details\", \"Dinners\", new { id = id });\n 21          }\n 22  \n 23          //\n 24          // AJAX: /Dinners/RegisterAjax/1\n 25          [Authorize, HttpPost]\n 26          public ActionResult RegisterAjax(int id)\n 27          {\n 28              RegisterForDinner(id);\n 29              return Content(\"Thanks - we'll see you there!\");\n 30          }\n 31  \n 32          private void RegisterForDinner(int id)\n 33          {\n 34              Dinner dinner = db.Dinners.Find(id);\n 35  "
+        lineNumber: 24
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_class: AuthorizeAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: AuthorizeAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 16          [Authorize]\n 17          public ActionResult Register(int id)\n 18          {\n 19              RegisterForDinner(id);\n 20              return RedirectToAction(\"Details\", \"Dinners\", new { id = id });\n 21          }\n 22  \n 23          //\n 24          // AJAX: /Dinners/RegisterAjax/1\n 25          [Authorize, HttpPost]\n 26          public ActionResult RegisterAjax(int id)\n 27          {\n 28              RegisterForDinner(id);\n 29              return Content(\"Thanks - we'll see you there!\");\n 30          }\n 31  \n 32          private void RegisterForDinner(int id)\n 33          {\n 34              Dinner dinner = db.Dinners.Find(id);\n 35  \n 36              if (!dinner.IsUserRegistered(User.Identity.Name))"
+        lineNumber: 25
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 19              RegisterForDinner(id);\n 20              return RedirectToAction(\"Details\", \"Dinners\", new { id = id });\n 21          }\n 22  \n 23          //\n 24          // AJAX: /Dinners/RegisterAjax/1\n 25          [Authorize, HttpPost]\n 26          public ActionResult RegisterAjax(int id)\n 27          {\n 28              RegisterForDinner(id);\n 29              return Content(\"Thanks - we'll see you there!\");\n 30          }\n 31  \n 32          private void RegisterForDinner(int id)\n 33          {\n 34              Dinner dinner = db.Dinners.Find(id);\n 35  \n 36              if (!dinner.IsUserRegistered(User.Identity.Name))\n 37              {\n 38                  RSVP rsvp = new RSVP();\n 39                  rsvp.AttendeeName = User.Identity.Name;"
+        lineNumber: 28
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_class: ContentResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: Content("Thanks - we'll see you there!")
+          syntax_type: type_usage
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 26          public ActionResult RegisterAjax(int id)\n 27          {\n 28              RegisterForDinner(id);\n 29              return Content(\"Thanks - we'll see you there!\");\n 30          }\n 31  \n 32          private void RegisterForDinner(int id)\n 33          {\n 34              Dinner dinner = db.Dinners.Find(id);\n 35  \n 36              if (!dinner.IsUserRegistered(User.Identity.Name))\n 37              {\n 38                  RSVP rsvp = new RSVP();\n 39                  rsvp.AttendeeName = User.Identity.Name;\n 40  \n 41                  dinner.RSVPs.Add(rsvp);\n 42                  db.SaveChanges();\n 43              }\n 44          }\n 45  \n 46          //"
         lineNumber: 35
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1928,15 +6185,93 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "28             return Content(\"Thanks - we'll see you there!\");\n29         }\n30 \n31         private void RegisterForDinner(int id)\n32         {\n33             Dinner dinner = db.Dinners.Find(id);\n34 \n35             if (!dinner.IsUserRegistered(User.Identity.Name))\n36             {\n37                 RSVP rsvp = new RSVP();\n38                 rsvp.AttendeeName = User.Identity.Name;\n39 \n40                 dinner.RSVPs.Add(rsvp);\n41                 db.SaveChanges();\n42             }\n43         }\n44 \n45         //\n46         // AJAX: /RSVP/CancelAjax/1\n47 \n48         [Authorize, HttpPost]\n"
+        codeSnip: " 29              return Content(\"Thanks - we'll see you there!\");\n 30          }\n 31  \n 32          private void RegisterForDinner(int id)\n 33          {\n 34              Dinner dinner = db.Dinners.Find(id);\n 35  \n 36              if (!dinner.IsUserRegistered(User.Identity.Name))\n 37              {\n 38                  RSVP rsvp = new RSVP();\n 39                  rsvp.AttendeeName = User.Identity.Name;\n 40  \n 41                  dinner.RSVPs.Add(rsvp);\n 42                  db.SaveChanges();\n 43              }\n 44          }\n 45  \n 46          //\n 47          // AJAX: /RSVP/CancelAjax/1\n 48  \n 49          [Authorize, HttpPost]"
         lineNumber: 38
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
           fqdn_class: Controller
           fqdn_field: User
           fqdn_namespace: System.Web.Mvc
-          symbol: User.Identity
+          symbol: User
           syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 39                  rsvp.AttendeeName = User.Identity.Name;\n 40  \n 41                  dinner.RSVPs.Add(rsvp);\n 42                  db.SaveChanges();\n 43              }\n 44          }\n 45  \n 46          //\n 47          // AJAX: /RSVP/CancelAjax/1\n 48  \n 49          [Authorize, HttpPost]\n 50          public ActionResult CancelAjax(int id)\n 51          {\n 52              Dinner dinner = db.Dinners.Find(id);\n 53  \n 54              RSVP rsvp = dinner.RSVPs.SingleOrDefault(r => this.User.Identity.Name ==  r.AttendeeName);\n 55              if (rsvp != null)\n 56              {\n 57                  db.RSVPs.Remove(rsvp);\n 58                  db.SaveChanges();\n 59              }"
+        lineNumber: 48
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_class: AuthorizeAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: AuthorizeAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 40  \n 41                  dinner.RSVPs.Add(rsvp);\n 42                  db.SaveChanges();\n 43              }\n 44          }\n 45  \n 46          //\n 47          // AJAX: /RSVP/CancelAjax/1\n 48  \n 49          [Authorize, HttpPost]\n 50          public ActionResult CancelAjax(int id)\n 51          {\n 52              Dinner dinner = db.Dinners.Find(id);\n 53  \n 54              RSVP rsvp = dinner.RSVPs.SingleOrDefault(r => this.User.Identity.Name ==  r.AttendeeName);\n 55              if (rsvp != null)\n 56              {\n 57                  db.RSVPs.Remove(rsvp);\n 58                  db.SaveChanges();\n 59              }\n 60  "
+        lineNumber: 49
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_class: ActionResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 44          }\n 45  \n 46          //\n 47          // AJAX: /RSVP/CancelAjax/1\n 48  \n 49          [Authorize, HttpPost]\n 50          public ActionResult CancelAjax(int id)\n 51          {\n 52              Dinner dinner = db.Dinners.Find(id);\n 53  \n 54              RSVP rsvp = dinner.RSVPs.SingleOrDefault(r => this.User.Identity.Name ==  r.AttendeeName);\n 55              if (rsvp != null)\n 56              {\n 57                  db.RSVPs.Remove(rsvp);\n 58                  db.SaveChanges();\n 59              }\n 60  \n 61              return Content(\"Sorry you can't make it!\");\n 62          }\n 63      }\n 64  }"
+        lineNumber: 53
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_class: Controller
+          fqdn_field: User
+          fqdn_namespace: System.Web.Mvc
+          symbol: this.User
+          syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 51          {\n 52              Dinner dinner = db.Dinners.Find(id);\n 53  \n 54              RSVP rsvp = dinner.RSVPs.SingleOrDefault(r => this.User.Identity.Name ==  r.AttendeeName);\n 55              if (rsvp != null)\n 56              {\n 57                  db.RSVPs.Remove(rsvp);\n 58                  db.SaveChanges();\n 59              }\n 60  \n 61              return Content(\"Sorry you can't make it!\");\n 62          }\n 63      }\n 64  }"
+        lineNumber: 60
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Controllers/RSVPController.cs
+          fqdn_class: ContentResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: Content("Sorry you can't make it!")
+          syntax_type: type_usage
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1947,12 +6282,52 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "0 \uFEFFusing System;\n1 using System.Data.Entity;\n2 using System.Data.Entity.Infrastructure;\n3 using System.Threading;\n4 using System.Web.Mvc;\n5 using WebMatrix.WebData;\n6 using NerdDinner.Models;\n7 \n8 namespace NerdDinner.Filters\n9 {\n10     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]\n11     public sealed class InitializeSimpleMembershipAttribute : ActionFilterAttribute\n12     {\n13         private static SimpleMembershipInitializer _initializer;\n14         private static object _initializerLock = new object();\n"
+        codeSnip: "  1  using System;\n  2  using System.Data.Entity;\n  3  using System.Data.Entity.Infrastructure;\n  4  using System.Threading;\n  5  using System.Web.Mvc;\n  6  using WebMatrix.WebData;\n  7  using NerdDinner.Models;\n  8  \n  9  namespace NerdDinner.Filters\n 10  {\n 11      [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]\n 12      public sealed class InitializeSimpleMembershipAttribute : ActionFilterAttribute\n 13      {\n 14          private static SimpleMembershipInitializer _initializer;\n 15          private static object _initializerLock = new object();"
         lineNumber: 4
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
+          fqdn_namespace: System.Web.Mvc
           symbol: System.Web.Mvc
           syntax_type: import
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: "  2  using System.Data.Entity;\n  3  using System.Data.Entity.Infrastructure;\n  4  using System.Threading;\n  5  using System.Web.Mvc;\n  6  using WebMatrix.WebData;\n  7  using NerdDinner.Models;\n  8  \n  9  namespace NerdDinner.Filters\n 10  {\n 11      [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]\n 12      public sealed class InitializeSimpleMembershipAttribute : ActionFilterAttribute\n 13      {\n 14          private static SimpleMembershipInitializer _initializer;\n 15          private static object _initializerLock = new object();\n 16          private static bool _isInitialized;\n 17  \n 18          public override void OnActionExecuting(ActionExecutingContext filterContext)\n 19          {\n 20              // Ensure ASP.NET Simple Membership is initialized only once per app start\n 21              LazyInitializer.EnsureInitialized(ref _initializer, ref _isInitialized, ref _initializerLock);\n 22          }"
+        lineNumber: 11
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
+          fqdn_class: ActionFilterAttribute
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionFilterAttribute
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: "  8  \n  9  namespace NerdDinner.Filters\n 10  {\n 11      [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]\n 12      public sealed class InitializeSimpleMembershipAttribute : ActionFilterAttribute\n 13      {\n 14          private static SimpleMembershipInitializer _initializer;\n 15          private static object _initializerLock = new object();\n 16          private static bool _isInitialized;\n 17  \n 18          public override void OnActionExecuting(ActionExecutingContext filterContext)\n 19          {\n 20              // Ensure ASP.NET Simple Membership is initialized only once per app start\n 21              LazyInitializer.EnsureInitialized(ref _initializer, ref _isInitialized, ref _initializerLock);\n 22          }\n 23  \n 24          private class SimpleMembershipInitializer\n 25          {\n 26              public SimpleMembershipInitializer()\n 27              {\n 28                  Database.SetInitializer<UsersContext>(null);"
+        lineNumber: 17
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Filters/InitializeSimpleMembershipAttribute.cs
+          fqdn_class: ActionExecutingContext
+          fqdn_namespace: System.Web.Mvc
+          symbol: ActionExecutingContext
+          syntax_type: type_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1963,12 +6338,14 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "0 \uFEFFusing System;\n1 using System.Collections.Generic;\n2 using System.Linq;\n3 using System.Reflection;\n4 using System.Web;\n5 using System.Web.Http;\n6 using System.Web.Mvc;\n7 using System.Web.Optimization;\n8 using System.Web.Routing;\n9 \n10 namespace NerdDinner\n11 {\n12     // Note: For instructions on enabling IIS6 or IIS7 classic mode, \n13     // visit http://go.microsoft.com/?LinkId=9394801\n14 \n15     public class MvcApplication : System.Web.HttpApplication\n16     {\n"
+        codeSnip: "  1  using System;\n  2  using System.Collections.Generic;\n  3  using System.Linq;\n  4  using System.Reflection;\n  5  using System.Web;\n  6  using System.Web.Http;\n  7  using System.Web.Mvc;\n  8  using System.Web.Optimization;\n  9  using System.Web.Routing;\n 10  \n 11  namespace NerdDinner\n 12  {\n 13      // Note: For instructions on enabling IIS6 or IIS7 classic mode, \n 14      // visit http://go.microsoft.com/?LinkId=9394801\n 15  \n 16      public class MvcApplication : System.Web.HttpApplication\n 17      {"
         lineNumber: 6
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
+          fqdn_namespace: System.Web.Mvc
           symbol: System.Web.Mvc
           syntax_type: import
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1979,7 +6356,7 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "9 \n10 namespace NerdDinner\n11 {\n12     // Note: For instructions on enabling IIS6 or IIS7 classic mode, \n13     // visit http://go.microsoft.com/?LinkId=9394801\n14 \n15     public class MvcApplication : System.Web.HttpApplication\n16     {\n17         protected void Application_Start()\n18         {\n19             AreaRegistration.RegisterAllAreas();\n20 \n21             WebApiConfig.Register(GlobalConfiguration.Configuration);\n22             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);\n23             RouteConfig.RegisterRoutes(RouteTable.Routes);\n24             BundleConfig.RegisterBundles(BundleTable.Bundles);\n25             AuthConfig.RegisterAuth();\n26 \n27             ModelBinderProviders.BinderProviders.Add(new EFModelBinderProvider());\n28 \n29             Version version = Assembly.GetExecutingAssembly().GetName().Version;\n"
+        codeSnip: " 10  \n 11  namespace NerdDinner\n 12  {\n 13      // Note: For instructions on enabling IIS6 or IIS7 classic mode, \n 14      // visit http://go.microsoft.com/?LinkId=9394801\n 15  \n 16      public class MvcApplication : System.Web.HttpApplication\n 17      {\n 18          protected void Application_Start()\n 19          {\n 20              AreaRegistration.RegisterAllAreas();\n 21  \n 22              WebApiConfig.Register(GlobalConfiguration.Configuration);\n 23              FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);\n 24              RouteConfig.RegisterRoutes(RouteTable.Routes);\n 25              BundleConfig.RegisterBundles(BundleTable.Bundles);\n 26              AuthConfig.RegisterAuth();\n 27  \n 28              ModelBinderProviders.BinderProviders.Add(new EFModelBinderProvider());\n 29  \n 30              Version version = Assembly.GetExecutingAssembly().GetName().Version;"
         lineNumber: 19
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
@@ -1988,6 +6365,7 @@
           fqdn_namespace: System.Web.Mvc
           symbol: AreaRegistration.RegisterAllAreas
           syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -1998,15 +6376,15 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "12     // Note: For instructions on enabling IIS6 or IIS7 classic mode, \n13     // visit http://go.microsoft.com/?LinkId=9394801\n14 \n15     public class MvcApplication : System.Web.HttpApplication\n16     {\n17         protected void Application_Start()\n18         {\n19             AreaRegistration.RegisterAllAreas();\n20 \n21             WebApiConfig.Register(GlobalConfiguration.Configuration);\n22             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);\n23             RouteConfig.RegisterRoutes(RouteTable.Routes);\n24             BundleConfig.RegisterBundles(BundleTable.Bundles);\n25             AuthConfig.RegisterAuth();\n26 \n27             ModelBinderProviders.BinderProviders.Add(new EFModelBinderProvider());\n28 \n29             Version version = Assembly.GetExecutingAssembly().GetName().Version;\n30             Application[\"Version\"] = string.Format(\"{0}.{1}\", version.Major, version.Minor);\n31         }\n32     }\n"
+        codeSnip: " 13      // Note: For instructions on enabling IIS6 or IIS7 classic mode, \n 14      // visit http://go.microsoft.com/?LinkId=9394801\n 15  \n 16      public class MvcApplication : System.Web.HttpApplication\n 17      {\n 18          protected void Application_Start()\n 19          {\n 20              AreaRegistration.RegisterAllAreas();\n 21  \n 22              WebApiConfig.Register(GlobalConfiguration.Configuration);\n 23              FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);\n 24              RouteConfig.RegisterRoutes(RouteTable.Routes);\n 25              BundleConfig.RegisterBundles(BundleTable.Bundles);\n 26              AuthConfig.RegisterAuth();\n 27  \n 28              ModelBinderProviders.BinderProviders.Add(new EFModelBinderProvider());\n 29  \n 30              Version version = Assembly.GetExecutingAssembly().GetName().Version;\n 31              Application[\"Version\"] = string.Format(\"{0}.{1}\", version.Major, version.Minor);\n 32          }\n 33      }"
         lineNumber: 22
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
-          fqdn_class: GlobalFilters
-          fqdn_field: Filters
+          fqdn_class: GlobalFilterCollection
           fqdn_namespace: System.Web.Mvc
           symbol: GlobalFilters.Filters
-          syntax_type: field_reference
+          syntax_type: type_usage
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -2017,15 +6395,16 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "17         protected void Application_Start()\n18         {\n19             AreaRegistration.RegisterAllAreas();\n20 \n21             WebApiConfig.Register(GlobalConfiguration.Configuration);\n22             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);\n23             RouteConfig.RegisterRoutes(RouteTable.Routes);\n24             BundleConfig.RegisterBundles(BundleTable.Bundles);\n25             AuthConfig.RegisterAuth();\n26 \n27             ModelBinderProviders.BinderProviders.Add(new EFModelBinderProvider());\n28 \n29             Version version = Assembly.GetExecutingAssembly().GetName().Version;\n30             Application[\"Version\"] = string.Format(\"{0}.{1}\", version.Major, version.Minor);\n31         }\n32     }\n33 }\n"
+        codeSnip: " 18          protected void Application_Start()\n 19          {\n 20              AreaRegistration.RegisterAllAreas();\n 21  \n 22              WebApiConfig.Register(GlobalConfiguration.Configuration);\n 23              FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);\n 24              RouteConfig.RegisterRoutes(RouteTable.Routes);\n 25              BundleConfig.RegisterBundles(BundleTable.Bundles);\n 26              AuthConfig.RegisterAuth();\n 27  \n 28              ModelBinderProviders.BinderProviders.Add(new EFModelBinderProvider());\n 29  \n 30              Version version = Assembly.GetExecutingAssembly().GetName().Version;\n 31              Application[\"Version\"] = string.Format(\"{0}.{1}\", version.Major, version.Minor);\n 32          }\n 33      }\n 34  }"
         lineNumber: 27
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Global.asax.cs
-          fqdn_class: ModelBinderProviders
-          fqdn_field: BinderProviders
-          fqdn_namespace: System.Web.Mvc
-          symbol: ModelBinderProviders.BinderProviders
-          syntax_type: field_reference
+          fqdn_class: Collection
+          fqdn_method: Add
+          fqdn_namespace: System.Collections.ObjectModel
+          symbol: BinderProviders.Add
+          syntax_type: method_reference
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/ModelBinders/DbGeographyModelBinder.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -2036,12 +6415,148 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "0 \uFEFFusing System;\n1 using System.Collections.Generic;\n2 using System.Data.Spatial;\n3 using System.Linq;\n4 using System.Web;\n5 using System.Web.Mvc;\n6 \n7 namespace NerdDinner\n8 {\n9     public class DbGeographyModelBinder : DefaultModelBinder\n10     {\n11         public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)\n12         {\n13             var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);\n14             if (valueProviderResult != null)\n15             {\n"
+        codeSnip: "  1  using System;\n  2  using System.Collections.Generic;\n  3  using System.Data.Spatial;\n  4  using System.Linq;\n  5  using System.Web;\n  6  using System.Web.Mvc;\n  7  \n  8  namespace NerdDinner\n  9  {\n 10      public class DbGeographyModelBinder : DefaultModelBinder\n 11      {\n 12          public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)\n 13          {\n 14              var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);\n 15              if (valueProviderResult != null)\n 16              {"
         lineNumber: 5
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/ModelBinders/DbGeographyModelBinder.cs
+          fqdn_namespace: System.Web.Mvc
           symbol: System.Web.Mvc
           syntax_type: import
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/ModelBinders/DbGeographyModelBinder.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: "  1  using System;\n  2  using System.Collections.Generic;\n  3  using System.Data.Spatial;\n  4  using System.Linq;\n  5  using System.Web;\n  6  using System.Web.Mvc;\n  7  \n  8  namespace NerdDinner\n  9  {\n 10      public class DbGeographyModelBinder : DefaultModelBinder\n 11      {\n 12          public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)\n 13          {\n 14              var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);\n 15              if (valueProviderResult != null)\n 16              {\n 17                  string[] latLongStr = valueProviderResult.AttemptedValue.Split(',');\n 18                  string point = string.Format(\"POINT ({0} {1})\", latLongStr[1], latLongStr[0]);\n 19                  //4326 format puts LONGITUDE first then LATITUDE\n 20                  DbGeography result = DbGeography.FromText(point, 4326);"
+        lineNumber: 9
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/ModelBinders/DbGeographyModelBinder.cs
+          fqdn_class: DefaultModelBinder
+          fqdn_namespace: System.Web.Mvc
+          symbol: DefaultModelBinder
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/ModelBinders/DbGeographyModelBinder.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: "  2  using System.Collections.Generic;\n  3  using System.Data.Spatial;\n  4  using System.Linq;\n  5  using System.Web;\n  6  using System.Web.Mvc;\n  7  \n  8  namespace NerdDinner\n  9  {\n 10      public class DbGeographyModelBinder : DefaultModelBinder\n 11      {\n 12          public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)\n 13          {\n 14              var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);\n 15              if (valueProviderResult != null)\n 16              {\n 17                  string[] latLongStr = valueProviderResult.AttemptedValue.Split(',');\n 18                  string point = string.Format(\"POINT ({0} {1})\", latLongStr[1], latLongStr[0]);\n 19                  //4326 format puts LONGITUDE first then LATITUDE\n 20                  DbGeography result = DbGeography.FromText(point, 4326);\n 21                  return result;\n 22              }"
+        lineNumber: 11
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/ModelBinders/DbGeographyModelBinder.cs
+          fqdn_class: ControllerContext
+          fqdn_namespace: System.Web.Mvc
+          symbol: ControllerContext
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/ModelBinders/DbGeographyModelBinder.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: "  4  using System.Linq;\n  5  using System.Web;\n  6  using System.Web.Mvc;\n  7  \n  8  namespace NerdDinner\n  9  {\n 10      public class DbGeographyModelBinder : DefaultModelBinder\n 11      {\n 12          public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)\n 13          {\n 14              var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);\n 15              if (valueProviderResult != null)\n 16              {\n 17                  string[] latLongStr = valueProviderResult.AttemptedValue.Split(',');\n 18                  string point = string.Format(\"POINT ({0} {1})\", latLongStr[1], latLongStr[0]);\n 19                  //4326 format puts LONGITUDE first then LATITUDE\n 20                  DbGeography result = DbGeography.FromText(point, 4326);\n 21                  return result;\n 22              }\n 23              return null;\n 24          }"
+        lineNumber: 13
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/ModelBinders/DbGeographyModelBinder.cs
+          fqdn_class: ValueProviderResult
+          fqdn_namespace: System.Web.Mvc
+          symbol: ValueProviderResult
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/ModelBinders/DbGeographyModelBinder.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: "  7  \n  8  namespace NerdDinner\n  9  {\n 10      public class DbGeographyModelBinder : DefaultModelBinder\n 11      {\n 12          public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)\n 13          {\n 14              var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);\n 15              if (valueProviderResult != null)\n 16              {\n 17                  string[] latLongStr = valueProviderResult.AttemptedValue.Split(',');\n 18                  string point = string.Format(\"POINT ({0} {1})\", latLongStr[1], latLongStr[0]);\n 19                  //4326 format puts LONGITUDE first then LATITUDE\n 20                  DbGeography result = DbGeography.FromText(point, 4326);\n 21                  return result;\n 22              }\n 23              return null;\n 24          }\n 25      }\n 26  \n 27      public class EFModelBinderProvider : IModelBinderProvider"
+        lineNumber: 16
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/ModelBinders/DbGeographyModelBinder.cs
+          fqdn_class: ValueProviderResult
+          fqdn_field: AttemptedValue
+          fqdn_namespace: System.Web.Mvc
+          symbol: valueProviderResult.AttemptedValue
+          syntax_type: field_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/ModelBinders/DbGeographyModelBinder.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 17                  string[] latLongStr = valueProviderResult.AttemptedValue.Split(',');\n 18                  string point = string.Format(\"POINT ({0} {1})\", latLongStr[1], latLongStr[0]);\n 19                  //4326 format puts LONGITUDE first then LATITUDE\n 20                  DbGeography result = DbGeography.FromText(point, 4326);\n 21                  return result;\n 22              }\n 23              return null;\n 24          }\n 25      }\n 26  \n 27      public class EFModelBinderProvider : IModelBinderProvider\n 28      {\n 29          public IModelBinder GetBinder(Type modelType)\n 30          {\n 31              if (modelType == typeof(DbGeography))\n 32              {\n 33                  return new DbGeographyModelBinder();\n 34              }\n 35              return null;\n 36          }\n 37      }"
+        lineNumber: 26
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/ModelBinders/DbGeographyModelBinder.cs
+          fqdn_class: IModelBinderProvider
+          fqdn_namespace: System.Web.Mvc
+          symbol: IModelBinderProvider
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/ModelBinders/DbGeographyModelBinder.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 19                  //4326 format puts LONGITUDE first then LATITUDE\n 20                  DbGeography result = DbGeography.FromText(point, 4326);\n 21                  return result;\n 22              }\n 23              return null;\n 24          }\n 25      }\n 26  \n 27      public class EFModelBinderProvider : IModelBinderProvider\n 28      {\n 29          public IModelBinder GetBinder(Type modelType)\n 30          {\n 31              if (modelType == typeof(DbGeography))\n 32              {\n 33                  return new DbGeographyModelBinder();\n 34              }\n 35              return null;\n 36          }\n 37      }\n 38  }"
+        lineNumber: 28
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/ModelBinders/DbGeographyModelBinder.cs
+          fqdn_class: IModelBinder
+          fqdn_namespace: System.Web.Mvc
+          symbol: IModelBinder
+          syntax_type: type_reference
+        isDependencyIncident: false
+      - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/ModelBinders/DbGeographyModelBinder.cs
+        message: |
+          The System.Web namespace is not available in .NET Core.
+          This namespace contains types that are specific to ASP.NET web applications and is replaced by ASP.NET Core components.
+
+          Migration actions:
+          - Replace System.Web.Mvc with Microsoft.AspNetCore.Mvc
+          - Replace System.Web.Http with ASP.NET Core Web API
+          - Update controller base classes and routing
+          - Migrate to ASP.NET Core middleware pipeline
+        codeSnip: " 23              return null;\n 24          }\n 25      }\n 26  \n 27      public class EFModelBinderProvider : IModelBinderProvider\n 28      {\n 29          public IModelBinder GetBinder(Type modelType)\n 30          {\n 31              if (modelType == typeof(DbGeography))\n 32              {\n 33                  return new DbGeographyModelBinder();\n 34              }\n 35              return null;\n 36          }\n 37      }\n 38  }"
+        lineNumber: 32
+        variables:
+          file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/ModelBinders/DbGeographyModelBinder.cs
+          fqdn_class: DefaultModelBinder
+          fqdn_namespace: System.Web.Mvc
+          symbol: new DbGeographyModelBinder()
+          syntax_type: type_usage
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/Dinner.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -2052,12 +6567,14 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "0 \uFEFFusing System;\n1 using System.Collections.Generic;\n2 using System.ComponentModel.DataAnnotations;\n3 using System.ComponentModel.DataAnnotations.Schema;\n4 using System.Data.Spatial;\n5 using System.Linq;\n6 using System.Web;\n7 using System.Web.Mvc;\n8 \n9 namespace NerdDinner.Models\n10 {\n11     public class Dinner\n12     {\n13         [HiddenInput(DisplayValue = false)]\n14         public int DinnerID { get; set; }\n15 \n16         [Required(ErrorMessage = \"Title is required\")]\n17         [StringLength(50, ErrorMessage = \"Title may not be longer than 50 characters\")]\n"
+        codeSnip: "  1  using System;\n  2  using System.Collections.Generic;\n  3  using System.ComponentModel.DataAnnotations;\n  4  using System.ComponentModel.DataAnnotations.Schema;\n  5  using System.Data.Spatial;\n  6  using System.Linq;\n  7  using System.Web;\n  8  using System.Web.Mvc;\n  9  \n 10  namespace NerdDinner.Models\n 11  {\n 12      public class Dinner\n 13      {\n 14          [HiddenInput(DisplayValue = false)]\n 15          public int DinnerID { get; set; }\n 16  \n 17          [Required(ErrorMessage = \"Title is required\")]\n 18          [StringLength(50, ErrorMessage = \"Title may not be longer than 50 characters\")]"
         lineNumber: 7
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/Dinner.cs
+          fqdn_namespace: System.Web.Mvc
           symbol: System.Web.Mvc
           syntax_type: import
+        isDependencyIncident: false
       - uri: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/Dinner.cs
         message: |
           The System.Web namespace is not available in .NET Core.
@@ -2068,63 +6585,56 @@
           - Replace System.Web.Http with ASP.NET Core Web API
           - Update controller base classes and routing
           - Migrate to ASP.NET Core middleware pipeline
-        codeSnip: "16         [Required(ErrorMessage = \"Title is required\")]\n17         [StringLength(50, ErrorMessage = \"Title may not be longer than 50 characters\")]\n18         public string Title { get; set; }\n19 \n20         [Required(ErrorMessage = \"Event Date is required\")]\n21         [Display(Name = \"Event Date\")]\n22         public DateTime EventDate { get; set; }\n23 \n24         [Required(ErrorMessage = \"Description is required\")]\n25         [StringLength(256, ErrorMessage = \"Description may not be longer than 256 characters\")]\n26         [DataType(DataType.MultilineText)]\n27         public string Description { get; set; }\n28 \n29         [StringLength(20, ErrorMessage = \"Hosted By name may not be longer than 20 characters\")]\n30         [Display(Name = \"Host's Name\")]\n31         public string HostedBy { get; set; }\n32 \n33         [Required(ErrorMessage = \"Contact info is required\")]\n34         [StringLength(20, ErrorMessage = \"Contact info may not be longer than 20 characters\")]\n35         [Display(Name = \"Contact Info\")]\n36         public string ContactPhone { get; set; }\n"
-        lineNumber: 26
+        codeSnip: "  4  using System.ComponentModel.DataAnnotations.Schema;\n  5  using System.Data.Spatial;\n  6  using System.Linq;\n  7  using System.Web;\n  8  using System.Web.Mvc;\n  9  \n 10  namespace NerdDinner.Models\n 11  {\n 12      public class Dinner\n 13      {\n 14          [HiddenInput(DisplayValue = false)]\n 15          public int DinnerID { get; set; }\n 16  \n 17          [Required(ErrorMessage = \"Title is required\")]\n 18          [StringLength(50, ErrorMessage = \"Title may not be longer than 50 characters\")]\n 19          public string Title { get; set; }\n 20  \n 21          [Required(ErrorMessage = \"Event Date is required\")]\n 22          [Display(Name = \"Event Date\")]\n 23          public DateTime EventDate { get; set; }\n 24  "
+        lineNumber: 13
         variables:
           file: file:///analyzer-lsp/examples/nerd-dinner/mvc4/NerdDinner/Models/Dinner.cs
-          fqdn_class: CachedDataAnnotationsMetadataAttributes
-          fqdn_field: DataType
+          fqdn_class: HiddenInputAttribute
           fqdn_namespace: System.Web.Mvc
-          symbol: DataType.MultilineText
-          syntax_type: field_reference
+          symbol: HiddenInputAttribute
+          syntax_type: annotation
+        isDependencyIncident: false
       links:
       - url: https://learn.microsoft.com/en-us/aspnet/core/migration/proper-to-2x
         title: Migrate from ASP.NET to ASP.NET Core
       - url: https://learn.microsoft.com/en-us/aspnet/core/migration/mvc
         title: System.Web namespace migration
+  errors:
+    dotnet-core-appdomain-01: Invalid pattern '*.AppDomain' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-appdomain-createdomain-01: Invalid pattern '*.AppDomain.CreateDomain' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-appdomain-unload-01: Invalid pattern '*.AppDomain.Unload' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-application-state-01: Invalid pattern '*.(Application|HttpContext.Application)' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-area-registration-01: Invalid pattern '*.AreaRegistration.RegisterAllAreas' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-assembly-codebase-01: Invalid pattern '*.Assembly.CodeBase' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-assembly-save-01: Invalid pattern '*.(AssemblyBuilder.Save|ModuleBuilder.CreateGlobalFunctions)' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-assemblybuilder-access-01: Invalid pattern '*.AssemblyBuilderAccess.(Save|RunAndSave|ReflectionOnly)' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-binaryformatter-01: Invalid pattern '*.BinaryFormatter' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-bundletable-01: Invalid pattern '*.BundleTable.Bundles' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-childaction-01: Invalid pattern '*.ChildActionOnly' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-configmanager-01: Invalid pattern '*.ConfigurationManager.AppSettings' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-connectionstrings-01: Invalid pattern '*.ConfigurationManager.ConnectionStrings' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-dotnetopenauth-01: Invalid pattern '*.DotNetOpenAuth.*' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-ef-dbset-01: Invalid pattern '*.DbSet' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-ef-initializer-01: Invalid pattern '*.Database.SetInitializer' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-globalconfig-01: Invalid pattern '*.GlobalConfiguration' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-globalfilters-01: Invalid pattern '*.GlobalFilters.Filters' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-httpcontext-current-01: Invalid pattern '*.HttpContext.Current' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-httpruntime-01: Invalid pattern '*.HttpRuntime.*' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-install-01: Invalid pattern '*.System.Configuration.Install' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-machinekey-01: Invalid pattern '*.MachineKey.*' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-modelbinder-01: Invalid pattern '*.ModelBinderProviders' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-multimodule-assembly-01: Invalid pattern '*.(DefineDynamicModule.*fileName|Assembly.LoadModule)' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-reflection-only-01: Invalid pattern '*.ReflectionOnlyLoad' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-routetable-01: Invalid pattern '*.RouteTable.Routes' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-server-mappath-01: Invalid pattern '*.Server.MapPath' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-session-01: Invalid pattern '*.(Session|HttpContext.Session)' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-thread-abort-01: Invalid pattern '*.Thread.Abort' at offset 1. Quantifier '*' following nothing.
+    dotnet-core-xslt-scripts-01: Invalid pattern '*.(XslCompiledTransform.*EnableScript|msxsl:script)' at offset 1. Quantifier '*' following nothing.
   unmatched:
-  - dotnet-core-antiforgery-01
-  - dotnet-core-appdomain-01
-  - dotnet-core-appdomain-createdomain-01
-  - dotnet-core-appdomain-unload-01
-  - dotnet-core-application-state-01
-  - dotnet-core-area-registration-01
-  - dotnet-core-assembly-codebase-01
-  - dotnet-core-assembly-save-01
-  - dotnet-core-assemblybuilder-access-01
-  - dotnet-core-binaryformatter-01
-  - dotnet-core-bundletable-01
-  - dotnet-core-childaction-01
-  - dotnet-core-configmanager-01
-  - dotnet-core-connectionstrings-01
-  - dotnet-core-dotnetopenauth-01
-  - dotnet-core-ef-dbset-01
-  - dotnet-core-ef-initializer-01
   - dotnet-core-ef-spatial-01
   - dotnet-core-forms-auth-01
-  - dotnet-core-globalconfig-01
-  - dotnet-core-globalfilters-01
-  - dotnet-core-httpapplication-01
-  - dotnet-core-httpcontext-current-01
-  - dotnet-core-httpruntime-01
-  - dotnet-core-install-01
-  - dotnet-core-machinekey-01
-  - dotnet-core-membership-01
-  - dotnet-core-modelbinder-01
-  - dotnet-core-multimodule-assembly-01
-  - dotnet-core-optimization-01
-  - dotnet-core-reflection-only-01
   - dotnet-core-remoting-01
-  - dotnet-core-routetable-01
-  - dotnet-core-routing-01
-  - dotnet-core-server-mappath-01
-  - dotnet-core-session-01
   - dotnet-core-system-drawing-01
-  - dotnet-core-thread-abort-01
-  - dotnet-core-transactionscope-01
   - dotnet-core-wcf-01
-  - dotnet-core-webapi-controller-01
-  - dotnet-core-webconfig-01
   - dotnet-core-webforms-01
   - dotnet-core-winforms-01
-  - dotnet-core-xslt-scripts-01


### PR DESCRIPTION
## Summary
- Regenerates `e2e-tests/demo-output.yaml` from the analyzer-lsp Demo Testing c-sharp job output ([run 29426178199 / job 87413971380](https://github.com/konveyor/analyzer-lsp/actions/runs/29426178199/job/87413971380?pr=1169))
- Fixes the `Run e2e verification` failure where `git diff --exit-code` did not match the committed baseline

## Context
PR #122 added the e2e test fixtures, but the committed `demo-output.yaml` was generated in a different environment. CI produced a substantially different violation set against the same images/rules.

## Test plan
- [ ] Merge this PR
- [ ] Re-run Demo Testing on analyzer-lsp PR #1169
- [ ] Confirm c-sharp `provider-tests` passes `Run e2e verification`


Made with [Cursor](https://cursor.com)