### PR TITLE
:sparkles: Warn when full analysis mode is requested

### DIFF
--- a/.github/workflows/demo-testing.yml
+++ b/.github/workflows/demo-testing.yml
@@ -45,7 +45,8 @@ jobs:
           uv run tests/test_runner.py setup
           uv run tests/test_runner.py run --provider csharp --verbose \
             --cmd "dotnet run --project src -- --port 9876 --log-file provider.log" \
-            --project net8-sample
+            --project net8-sample \
+            --project nerd-dinner
       - name: Named pipe test
         if: runner.os == 'Windows'
         shell: pwsh

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ obj/
 target/
 testdata/repos/
 testdata/results/
+provider.log
+__pycache__/

--- a/src/Services/ProviderService.cs
+++ b/src/Services/ProviderService.cs
@@ -7,6 +7,12 @@ namespace CSharpProvider.Services;
 
 // Provider.ProviderService.ProviderServiceBase is the base class generated from
 // provider.proto.
+public static class AnalysisMode
+{
+    public const string SourceOnly = "source-only";
+    public const string Full = "full";
+}
+
 public class ProviderService : Provider.ProviderService.ProviderServiceBase
 {
     private readonly ProviderConfig _config;
@@ -40,6 +46,13 @@ public class ProviderService : Provider.ProviderService.ProviderServiceBase
         _logger.LogInformation("Init called with location={Location}, analysisMode={Mode}",
             request.Location, request.AnalysisMode);
 
+        if (request.AnalysisMode == AnalysisMode.Full)
+        {
+            _logger.LogWarning(
+                "Analysis mode '{Mode}' is not supported. Running source-only analysis",
+                request.AnalysisMode);
+        }
+
         try
         {
             var loader = new ProjectLoader(_logger, _packageResolver);
@@ -57,7 +70,7 @@ public class ProviderService : Provider.ProviderService.ProviderServiceBase
                 BuiltinConfig = new Config
                 {
                     Location = request.Location,
-                    AnalysisMode = "source-only"
+                    AnalysisMode = AnalysisMode.SourceOnly
                 }
             };
         }

--- a/tests/suites/nerd-dinner/_.json
+++ b/tests/suites/nerd-dinner/_.json
@@ -10,6 +10,7 @@
     "system-web-http.json",
     "system-data-entity.json",
     "nerd-dinner-internal.json",
-    "system-web-mvc-controller.json"
+    "system-web-mvc-controller.json",
+    "init-full.json"
   ]
 }

--- a/tests/suites/nerd-dinner/init-full.expected.json
+++ b/tests/suites/nerd-dinner/init-full.expected.json
@@ -1,0 +1,6 @@
+{
+  "successful": true,
+  "builtinConfig": {
+    "analysisMode": "source-only"
+  }
+}

--- a/tests/suites/nerd-dinner/init-full.json
+++ b/tests/suites/nerd-dinner/init-full.json
@@ -1,0 +1,4 @@
+{
+  "location": "mvc4",
+  "analysisMode": "full"
+}

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -307,6 +307,40 @@ def compare_results(actual: dict[str, Any], expected: dict[str, Any]) -> tuple[b
     return True, "ok"
 
 
+def normalize_init_response(response: dict[str, Any] | None) -> dict[str, Any]:
+    """Reduce an Init response to the stable fields worth asserting.
+
+    Drops machine-specific fields (builtinConfig.location, id) so goldens are
+    portable across machines.
+    """
+    if not response or "_error" in response:
+        return response or {}
+    return {
+        "successful": response.get("successful", False),
+        "analysisMode": response.get("builtinConfig", {}).get("analysisMode"),
+    }
+
+
+def compare_init(actual: dict[str, Any], expected: dict[str, Any]) -> tuple[bool, str]:
+    if "_error" in actual:
+        return False, f"actual has error: {actual['_error']}"
+
+    a = normalize_init_response(actual)
+    e = normalize_init_response(expected)
+
+    if a.get("successful") != e.get("successful"):
+        return False, (
+            f"successful mismatch: got {a.get('successful')}, "
+            f"expected {e.get('successful')}"
+        )
+    if a.get("analysisMode") != e.get("analysisMode"):
+        return False, (
+            f"analysisMode mismatch: got {a.get('analysisMode')}, "
+            f"expected {e.get('analysisMode')}"
+        )
+    return True, "ok"
+
+
 def validate_manifests(
     manifests: dict[str, Manifest], update: bool
 ) -> tuple[list[str], list[str]]:
@@ -480,7 +514,7 @@ def run_project(
         with open(step_path) as f:
             request_data: dict[str, Any] = json.load(f)
 
-        is_init = step_name == "init"
+        is_init = step_name == "init" or step_name.startswith("init-")
 
         if is_init:
             location = resolve_init_location(project, manifest, request_data, repo_root=repo_root)
@@ -495,14 +529,16 @@ def run_project(
             result_file = project_result_dir / f"{step_name}.result.json"
             result_file.write_text(json.dumps(response, indent=2))
 
+            expected_path = test_dir / f"{step_name}.expected.json"
+
             if update:
-                expected_path = test_dir / f"{step_name}.expected.json"
                 expected_path.write_text(json.dumps(response, indent=2))
 
             if response and "_error" not in response:
-                ok = response.get("successful", False)
-                err = response.get("error", "")
-                status = "PASS" if ok else f"FAIL ({err})"
+                with open(expected_path) as f:
+                    expected = json.load(f)
+                ok, msg = compare_init(response, expected)
+                status = "PASS" if ok else f"FAIL: {msg}"
             else:
                 err_msg = (response or {}).get("_error", "unknown error")
                 status = f"ERROR ({err_msg[:100]})"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -532,9 +532,13 @@ def run_project(
             expected_path = test_dir / f"{step_name}.expected.json"
 
             if update:
-                expected_path.write_text(json.dumps(response, indent=2))
+                expected_path.write_text(
+                    json.dumps(normalize_init_response(response), indent=2)
+                )
 
-            if response and "_error" not in response:
+            if no_check:
+                status = "RAN"
+            elif response and "_error" not in response:
                 with open(expected_path) as f:
                     expected = json.load(f)
                 ok, msg = compare_init(response, expected)


### PR DESCRIPTION
Full analysis mode is not supported. When requested, log a warning and gracefully fall back to source-only analysis instead of silently downgrading.

Resolves #121 
Resolves #97 